### PR TITLE
Add support for Hetzner dedicated servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hetznercloud/hcloud-go v1.33.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	github.com/syself/hrobot-go v0.2.4
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	k8s.io/api v0.20.13
 	k8s.io/apimachinery v0.20.13

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,9 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJ
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -386,6 +387,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syself/hrobot-go v0.2.4 h1:/XjtE7UjXPfp4NCM3NNjfKrex0biKBUVgHRNPp7kmXg=
+github.com/syself/hrobot-go v0.2.4/go.mod h1:Oy47yZs+fJKcSh38S3OiNJdY34MXb0pkk796UnpYBnc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -652,8 +655,9 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/hcops"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/hcloud-go/hcloud/metadata"
+	hrobot "github.com/syself/hrobot-go"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 )
@@ -37,6 +38,10 @@ const (
 	hcloudEndpointENVVar = "HCLOUD_ENDPOINT"
 	hcloudNetworkENVVar  = "HCLOUD_NETWORK"
 	hcloudDebugENVVar    = "HCLOUD_DEBUG"
+
+	robotUserNameENVVar = "ROBOT_USER_NAME"
+	robotPasswordENVVar = "ROBOT_PASSWORD"
+
 	// Disable the "master/server is attached to the network" check against the metadata service.
 	hcloudNetworkDisableAttachedCheckENVVar  = "HCLOUD_NETWORK_DISABLE_ATTACHED_CHECK"
 	hcloudInstancesAddressFamily             = "HCLOUD_INSTANCES_ADDRESS_FAMILY"
@@ -48,11 +53,19 @@ const (
 	hcloudLoadBalancersDisableIPv6           = "HCLOUD_LOAD_BALANCERS_DISABLE_IPV6"
 	nodeNameENVVar                           = "NODE_NAME"
 	providerName                             = "hcloud"
+	providerNameRobot                        = "hetzner"
 	providerVersion                          = "v1.9.1"
+	hostNamePrefixHCloud                     = "hcloud//"
+	hostNamePrefixRobot                      = "robot//"
+)
+
+var (
+	errMissingRobotCredentials = errors.New("missing robot credentials - cannot connect to robot API")
 )
 
 type cloud struct {
 	client       *hcloud.Client
+	robotClient  hrobot.RobotClient
 	instances    *instances
 	zones        *zones
 	routes       *routes
@@ -87,6 +100,14 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 	}
 	client := hcloud.NewClient(opts...)
 	metadataClient := metadata.NewClient()
+
+	robotUserName, foundRobotUserName := os.LookupEnv(robotUserNameENVVar)
+	robotPassword, foundRobotPassword := os.LookupEnv(robotPasswordENVVar)
+
+	var robotClient hrobot.RobotClient
+	if foundRobotUserName && foundRobotPassword {
+		robotClient = hrobot.NewBasicAuthClient(robotUserName, robotPassword)
+	}
 
 	var networkID int
 	if v, ok := os.LookupEnv(hcloudNetworkENVVar); ok {
@@ -134,6 +155,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		CertOps:       &hcops.CertificateOps{CertClient: &client.Certificate},
 		ActionClient:  &client.Action,
 		NetworkClient: &client.Network,
+		RobotClient:   robotClient,
 		NetworkID:     networkID,
 		Defaults:      lbOpsDefaults,
 	}
@@ -150,8 +172,9 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 
 	return &cloud{
 		client:       client,
-		zones:        newZones(client, nodeName),
-		instances:    newInstances(client, instancesAddressFamily),
+		robotClient:  robotClient,
+		zones:        newZones(client, robotClient, nodeName),
+		instances:    newInstances(client, robotClient, instancesAddressFamily),
 		loadBalancer: loadBalancers,
 		routes:       nil,
 		networkID:    networkID,

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -29,12 +29,14 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/hcloud-go/hcloud/schema"
 	"github.com/stretchr/testify/assert"
+	hrobot "github.com/syself/hrobot-go"
 )
 
 type testEnv struct {
-	Server *httptest.Server
-	Mux    *http.ServeMux
-	Client *hcloud.Client
+	Server      *httptest.Server
+	Mux         *http.ServeMux
+	Client      *hcloud.Client
+	RobotClient hrobot.RobotClient
 }
 
 func (env *testEnv) Teardown() {
@@ -42,6 +44,7 @@ func (env *testEnv) Teardown() {
 	env.Server = nil
 	env.Mux = nil
 	env.Client = nil
+	env.RobotClient = nil
 }
 
 func newTestEnv() testEnv {
@@ -53,10 +56,13 @@ func newTestEnv() testEnv {
 		hcloud.WithBackoffFunc(func(_ int) time.Duration { return 0 }),
 		hcloud.WithDebugWriter(os.Stdout),
 	)
+	robotClient := hrobot.NewBasicAuthClient("", "")
+	robotClient.SetBaseURL(server.URL + "/robot")
 	return testEnv{
-		Server: server,
-		Mux:    mux,
-		Client: client,
+		Server:      server,
+		Mux:         mux,
+		Client:      client,
+		RobotClient: robotClient,
 	}
 }
 
@@ -143,6 +149,8 @@ func TestCloud(t *testing.T) {
 		"HCLOUD_ENDPOINT", env.Server.URL,
 		"HCLOUD_TOKEN", "jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jN_NOT_VALID_dzhepnahq",
 		"NODE_NAME", "test",
+		"ROBOT_USER_NAME", "user",
+		"ROBOT_PASSWORD", "pass123",
 	)
 	defer resetEnv()
 	env.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	hrobot "github.com/syself/hrobot-go"
+	"github.com/syself/hrobot-go/models"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
@@ -38,36 +40,58 @@ const (
 
 type instances struct {
 	client        *hcloud.Client
+	robotClient   hrobot.RobotClient
 	addressFamily addressFamily
 }
 
-func newInstances(client *hcloud.Client, addressFamily addressFamily) *instances {
-	return &instances{client, addressFamily}
+func newInstances(client *hcloud.Client, robotClient hrobot.RobotClient, addressFamily addressFamily) *instances {
+	return &instances{client, robotClient, addressFamily}
 }
 
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	const op = "hcloud/instances.NodeAddressesByProviderID"
 
-	id, err := providerIDToServerID(providerID)
+	id, isHCloudServer, err := providerIDToServerID(providerID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
-	server, err := getServerByID(ctx, i.client, id)
+	if isHCloudServer {
+		server, err := getHCloudServerByID(ctx, i.client, id)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", op, err)
+		}
+		return i.hcloudNodeAddresses(ctx, server), nil
+	}
+
+	server, err := getRobotServerByID(ctx, i.robotClient, id)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	return i.nodeAddresses(ctx, server), nil
+	return i.robotNodeAddresses(ctx, server), nil
 }
 
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	const op = "hcloud/instances.NodeAddresses"
 
-	server, err := getServerByName(ctx, i.client, string(nodeName))
+	isHCloudServer, err := isHCloudServerByName(string(nodeName))
+	if err != nil {
+		return nil, err
+	}
+
+	if isHCloudServer {
+		server, err := getHCloudServerByName(ctx, i.client, string(nodeName))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", op, err)
+		}
+		return i.hcloudNodeAddresses(ctx, server), nil
+	}
+
+	server, err := getRobotServerByName(ctx, i.robotClient, string(nodeName))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
-	return i.nodeAddresses(ctx, server), nil
+	return i.robotNodeAddresses(ctx, server), nil
 }
 
 func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (string, error) {
@@ -83,36 +107,70 @@ func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (st
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	const op = "hcloud/instances.InstanceID"
 
-	server, err := getServerByName(ctx, i.client, string(nodeName))
+	isHCloudServer, err := isHCloudServerByName(string(nodeName))
+	if err != nil {
+		return "", err
+	}
+
+	if isHCloudServer {
+		server, err := getHCloudServerByName(ctx, i.client, string(nodeName))
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", op, err)
+		}
+		return strconv.Itoa(server.ID), nil
+	}
+
+	server, err := getRobotServerByName(ctx, i.robotClient, string(nodeName))
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", op, err)
 	}
-	return strconv.Itoa(server.ID), nil
+	return strconv.Itoa(server.ServerNumber), nil
 }
 
 func (i *instances) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	const op = "hcloud/instances.InstanceType"
 
-	server, err := getServerByName(ctx, i.client, string(nodeName))
+	isHCloudServer, err := isHCloudServerByName(string(nodeName))
+	if err != nil {
+		return "", err
+	}
+
+	if isHCloudServer {
+		server, err := getHCloudServerByName(ctx, i.client, string(nodeName))
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", op, err)
+		}
+		return server.ServerType.Name, nil
+	}
+
+	server, err := getRobotServerByName(ctx, i.robotClient, string(nodeName))
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", op, err)
 	}
-	return server.ServerType.Name, nil
+	return server.Product, nil
 }
 
 func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	const op = "hcloud/instances.InstanceTypeByProviderID"
 
-	id, err := providerIDToServerID(providerID)
+	id, isHCloudServer, err := providerIDToServerID(providerID)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", op, err)
 	}
 
-	server, err := getServerByID(ctx, i.client, id)
+	if isHCloudServer {
+		server, err := getHCloudServerByID(ctx, i.client, id)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", op, err)
+		}
+		return server.ServerType.Name, nil
+	}
+
+	server, err := getRobotServerByID(ctx, i.robotClient, id)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", op, err)
 	}
-	return server.ServerType.Name, nil
+	return server.Product, nil
 }
 
 func (i *instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
@@ -126,34 +184,54 @@ func (i *instances) CurrentNodeName(ctx context.Context, hostname string) (types
 func (i instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	const op = "hcloud/instances.InstanceExistsByProviderID"
 
-	id, err := providerIDToServerID(providerID)
+	id, isHCloudServer, err := providerIDToServerID(providerID)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", op, err)
 	}
 
-	server, _, err := i.client.Server.GetByID(ctx, id)
+	if isHCloudServer {
+		server, _, err := i.client.Server.GetByID(ctx, id)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", op, err)
+		}
+		return server != nil, nil
+	}
+
+	if i.robotClient == nil {
+		return false, errMissingRobotCredentials
+	}
+
+	server, err := i.robotClient.ServerGet(id)
 	if err != nil {
+		if models.IsError(err, models.ErrorCodeNotFound) {
+			return false, nil
+		}
 		return false, fmt.Errorf("%s: %w", op, err)
 	}
-	return server != nil, nil
+	return isRobotServerInCluster(server.Name), nil
 }
 
 func (i instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	const op = "hcloud/instances.InstanceShutdownByProviderID"
 
-	id, err := providerIDToServerID(providerID)
+	id, isHCloudServer, err := providerIDToServerID(providerID)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", op, err)
 	}
 
-	server, _, err := i.client.Server.GetByID(ctx, id)
-	if err != nil {
-		return false, fmt.Errorf("%s: %w", op, err)
+	if isHCloudServer {
+		server, _, err := i.client.Server.GetByID(ctx, id)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", op, err)
+		}
+		return server != nil && server.Status == hcloud.ServerStatusOff, nil
 	}
-	return server != nil && server.Status == hcloud.ServerStatusOff, nil
+
+	// Robot does not support shutdowns
+	return false, nil
 }
 
-func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []v1.NodeAddress {
+func (i *instances) hcloudNodeAddresses(ctx context.Context, server *hcloud.Server) []v1.NodeAddress {
 	var addresses []v1.NodeAddress
 	addresses = append(
 		addresses,
@@ -193,5 +271,33 @@ func (i *instances) nodeAddresses(ctx context.Context, server *hcloud.Server) []
 
 		}
 	}
+	return addresses
+}
+
+func (i *instances) robotNodeAddresses(ctx context.Context, server *models.Server) []v1.NodeAddress {
+	var addresses []v1.NodeAddress
+	addresses = append(
+		addresses,
+		v1.NodeAddress{Type: v1.NodeHostName, Address: server.Name},
+	)
+
+	if i.addressFamily == AddressFamilyIPv6 || i.addressFamily == AddressFamilyDualStack {
+		// For a given IPv6 network of 2a01:f48:111:4221::, the instance address is 2a01:f48:111:4221::1
+		host_address := server.ServerIPv6Net
+		host_address = host_address + "1"
+
+		addresses = append(
+			addresses,
+			v1.NodeAddress{Type: v1.NodeExternalIP, Address: host_address},
+		)
+	}
+
+	if i.addressFamily == AddressFamilyIPv4 || i.addressFamily == AddressFamilyDualStack {
+		addresses = append(
+			addresses,
+			v1.NodeAddress{Type: v1.NodeExternalIP, Address: server.ServerIP},
+		)
+	}
+
 	return addresses
 }

--- a/hcloud/zones.go
+++ b/hcloud/zones.go
@@ -19,61 +19,130 @@ package hcloud
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	hrobot "github.com/syself/hrobot-go"
+	"github.com/syself/hrobot-go/models"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 )
 
 type zones struct {
-	client   *hcloud.Client
-	nodeName string // name of the node the programm is running on
+	client      *hcloud.Client
+	robotClient hrobot.RobotClient
+	nodeName    string // name of the node the programm is running on
 }
 
-func newZones(client *hcloud.Client, nodeName string) *zones {
-	return &zones{client, nodeName}
+func newZones(hcloudClient *hcloud.Client, robotClient hrobot.RobotClient, nodeName string) *zones {
+	return &zones{client: hcloudClient, robotClient: robotClient, nodeName: nodeName}
 }
 
 func (z zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 	const op = "hcloud/zones.GetZone"
 
-	server, err := getServerByName(ctx, z.client, z.nodeName)
+	isHCloudServer, err := isHCloudServerByName(z.nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
 	}
-	return zoneFromServer(server), nil
+
+	if isHCloudServer {
+		server, err := getHCloudServerByName(ctx, z.client, z.nodeName)
+		if err != nil {
+			return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
+		}
+		return zoneFromHCloudServer(server), nil
+	}
+
+	if z.robotClient == nil {
+		return cloudprovider.Zone{}, errMissingRobotCredentials
+	}
+
+	server, err := getRobotServerByName(ctx, z.robotClient, z.nodeName)
+	if err != nil {
+		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
+	}
+	return zoneFromRobotServer(server), nil
 }
 
 func (z zones) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	const op = "hcloud/zones.GetZoneByProviderID"
 
-	id, err := providerIDToServerID(providerID)
+	id, isHCloudServer, err := providerIDToServerID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
 	}
 
-	server, err := getServerByID(ctx, z.client, id)
+	if isHCloudServer {
+		server, err := getHCloudServerByID(ctx, z.client, id)
+		if err != nil {
+			return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
+		}
+
+		return zoneFromHCloudServer(server), nil
+	}
+
+	if z.robotClient == nil {
+		return cloudprovider.Zone{}, errMissingRobotCredentials
+	}
+
+	server, err := getRobotServerByID(ctx, z.robotClient, id)
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
 	}
 
-	return zoneFromServer(server), nil
+	return zoneFromRobotServer(server), nil
 }
 
 func (z zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
 	const op = "hcloud/zones.GetZoneByNodeName"
 
-	server, err := getServerByName(ctx, z.client, string(nodeName))
+	isHCloudServer, err := isHCloudServerByName(string(nodeName))
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
 	}
 
-	return zoneFromServer(server), nil
+	if isHCloudServer {
+		server, err := getHCloudServerByName(ctx, z.client, string(nodeName))
+		if err != nil {
+			return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
+		}
+		return zoneFromHCloudServer(server), nil
+	}
+
+	if z.robotClient == nil {
+		return cloudprovider.Zone{}, errMissingRobotCredentials
+	}
+
+	server, err := getRobotServerByName(ctx, z.robotClient, string(nodeName))
+	if err != nil {
+		return cloudprovider.Zone{}, fmt.Errorf("%s: %w", op, err)
+	}
+
+	return zoneFromRobotServer(server), nil
 }
 
-func zoneFromServer(server *hcloud.Server) cloudprovider.Zone {
+func zoneFromHCloudServer(server *hcloud.Server) cloudprovider.Zone {
+	region := server.Datacenter.Location.Name
 	return cloudprovider.Zone{
-		Region:        server.Datacenter.Location.Name,
-		FailureDomain: server.Datacenter.Name,
+		Region:        region,
+		FailureDomain: failureDomainFromRegion(region),
 	}
+}
+
+func zoneFromRobotServer(server *models.Server) cloudprovider.Zone {
+	region := strings.ToLower(server.Dc[:4])
+	return cloudprovider.Zone{
+		Region:        region,
+		FailureDomain: failureDomainFromRegion(region),
+	}
+}
+
+func failureDomainFromRegion(region string) string {
+	return map[string]string{
+		"nbg1": "eu-central",
+		"fsn1": "eu-central",
+		"hel1": "eu-central",
+		"ash":  "us-east",
+	}[region]
 }

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/annotation"
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	hrobot "github.com/syself/hrobot-go"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -47,6 +49,9 @@ type HCloudLoadBalancerClient interface {
 	AddServerTarget(ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddServerTargetOpts) (*hcloud.Action, *hcloud.Response, error)
 	RemoveServerTarget(ctx context.Context, lb *hcloud.LoadBalancer, server *hcloud.Server) (*hcloud.Action, *hcloud.Response, error)
 
+	AddIPTarget(ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddIPTargetOpts) (*hcloud.Action, *hcloud.Response, error)
+	RemoveIPTarget(ctx context.Context, lb *hcloud.LoadBalancer, server net.IP) (*hcloud.Action, *hcloud.Response, error)
+
 	AttachToNetwork(ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAttachToNetworkOpts) (*hcloud.Action, *hcloud.Response, error)
 	DetachFromNetwork(ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerDetachFromNetworkOpts) (*hcloud.Action, *hcloud.Response, error)
 
@@ -65,6 +70,7 @@ type LoadBalancerOps struct {
 	LBClient      HCloudLoadBalancerClient
 	ActionClient  HCloudActionClient
 	NetworkClient HCloudNetworkClient
+	RobotClient   hrobot.RobotClient
 	CertOps       *CertificateOps
 	RetryDelay    time.Duration
 	NetworkID     int
@@ -487,14 +493,24 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	var (
 		// Set of all K8S server IDs currently assigned as nodes to this
 		// cluster.
-		k8sNodeIDs   = make(map[int]bool)
-		k8sNodeNames = make(map[int]string)
+		k8sNodeIDsHCloud = make(map[int]bool)
+		k8sNodeIDsRobot  = make(map[int]bool)
+		k8sNodeNames     = make(map[int]string)
 
+		robotIPsToIDs = make(map[string]int)
+		robotIDToIPv4 = make(map[int]string)
+		robotIDToIPv6 = make(map[int]string)
 		// Set of server IDs assigned as targets to the HC Load Balancer. Some
 		// of the entries may get deleted during reconcilement. In this case
 		// the hclbTargetIDs[id] is always false. If hclbTargetIDs[id] is true,
 		// the node with this server id is assigned to the K8S cluster.
 		hclbTargetIDs = make(map[int]bool)
+
+		// Set of server IPs assigned as targets to the HC Load Balancer. Some
+		// of the entries may get deleted during reconcilement. In this case
+		// the hclbTargetIPs[id] is always false. If hclbTargetIPs[id] is true,
+		// the node with this server id is assigned to the K8S cluster.
+		hclbTargetIPs = make(map[string]bool)
 
 		changed bool
 	)
@@ -509,45 +525,93 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 
 	// Extract HC server IDs of all K8S nodes assigned to the K8S cluster.
 	for _, node := range nodes {
-		id, err := providerIDToServerID(node.Spec.ProviderID)
+		id, isHCloudServer, err := providerIDToServerID(node.Spec.ProviderID)
 		if err != nil {
 			return changed, fmt.Errorf("%s: %w", op, err)
 		}
-		k8sNodeIDs[id] = true
+		if isHCloudServer {
+			k8sNodeIDsHCloud[id] = true
+		} else {
+			k8sNodeIDsRobot[id] = true
+		}
 		k8sNodeNames[id] = node.Name
+	}
+
+	// List all robot servers to check whether the ip targets of the load balancer
+	// correspond to a dedicated server
+	dedicatedServers, err := l.RobotClient.ServerGetList()
+	if err != nil {
+		return changed, fmt.Errorf("%s: failed to get list of dedicated servers: %w", op, err)
+	}
+
+	for _, s := range dedicatedServers {
+		robotIPsToIDs[s.ServerIP] = s.ServerNumber
+		robotIPsToIDs[s.ServerIPv6Net+"1"] = s.ServerNumber
+		robotIDToIPv4[s.ServerNumber] = s.ServerIP
+		robotIDToIPv6[s.ServerNumber] = s.ServerIPv6Net + "1"
 	}
 
 	// Extract IDs of the hc Load Balancer's server targets. Along the way,
 	// Remove all server targets from the HC Load Balancer which are currently
 	// not assigned as nodes to the K8S Load Balancer.
 	for _, target := range lb.Targets {
-		if target.Type != hcloud.LoadBalancerTargetTypeServer {
-			continue
+		if target.Type == hcloud.LoadBalancerTargetTypeServer {
+			id := target.Server.Server.ID
+			recreate := target.UsePrivateIP != usePrivateIP
+			hclbTargetIDs[id] = k8sNodeIDsHCloud[id] && !recreate
+			if hclbTargetIDs[id] {
+				continue
+			}
+
+			klog.InfoS("remove target", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
+			// Target needs to be re-created or node currently not in use by k8s
+			// Load Balancer. Remove it from the HC Load Balancer
+			a, _, err := l.LBClient.RemoveServerTarget(ctx, lb, target.Server.Server)
+			if err != nil {
+				return changed, fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
+			}
+			if err := WatchAction(ctx, l.ActionClient, a); err != nil {
+				return changed, fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
+			}
+			changed = true
 		}
 
-		id := target.Server.Server.ID
-		recreate := target.UsePrivateIP != usePrivateIP
-		hclbTargetIDs[id] = k8sNodeIDs[id] && !recreate
-		if hclbTargetIDs[id] {
-			continue
-		}
+		if target.Type == hcloud.LoadBalancerTargetTypeIP {
+			ip := target.IP.IP
+			id, foundServer := robotIPsToIDs[ip]
+			hclbTargetIPs[ip] = foundServer && k8sNodeIDsRobot[id]
+			if hclbTargetIPs[ip] {
+				continue
+			}
 
-		klog.InfoS("remove target", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
-		// Target needs to be re-created or node currently not in use by k8s
-		// Load Balancer. Remove it from the HC Load Balancer
-		a, _, err := l.LBClient.RemoveServerTarget(ctx, lb, target.Server.Server)
-		if err != nil {
-			return changed, fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
+			klog.InfoS("remove target", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
+			// Node currently not in use by k8s Load Balancer. Remove it from the HC Load Balancer.
+			a, _, err := l.LBClient.RemoveIPTarget(ctx, lb, net.IP([]byte(ip)))
+			if err != nil {
+				var e error
+				if foundServer {
+					e = fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
+				} else {
+					e = fmt.Errorf("%s: targetIP: %s: %w", op, ip, err)
+				}
+				return changed, e
+			}
+			if err := WatchAction(ctx, l.ActionClient, a); err != nil {
+				var e error
+				if foundServer {
+					e = fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
+				} else {
+					e = fmt.Errorf("%s: targetIP: %s: %w", op, ip, err)
+				}
+				return changed, e
+			}
+			changed = true
 		}
-		if err := WatchAction(ctx, l.ActionClient, a); err != nil {
-			return changed, fmt.Errorf("%s: target: %s: %w", op, k8sNodeNames[id], err)
-		}
-		changed = true
 	}
 
 	// Assign the servers which are currently assigned as nodes
 	// to the K8S Load Balancer as server targets to the HC Load Balancer.
-	for id := range k8sNodeIDs {
+	for id := range k8sNodeIDsHCloud {
 		// Don't assign the node again if it is already assigned to the HC load
 		// balancer.
 		if hclbTargetIDs[id] {
@@ -573,6 +637,40 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		changed = true
 	}
 
+	// Assign the dedicated servers which are currently assigned as nodes
+	// to the K8S Load Balancer as IP targets to the HC Load Balancer.
+	for id := range k8sNodeIDsRobot {
+		for _, ip := range []string{
+			robotIDToIPv4[id],
+			robotIDToIPv6[id],
+		} {
+			// Don't assign the node again if it is already assigned to the HC load
+			// balancer.
+			if hclbTargetIPs[ip] {
+				continue
+			}
+			if ip == "" {
+				klog.InfoS("k8s node found but no corresponding server in robot", "id", id)
+				continue
+			}
+			klog.InfoS("add target", "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
+			opts := hcloud.LoadBalancerAddIPTargetOpts{
+				IP: net.IP([]byte(ip)),
+			}
+			a, _, err := l.LBClient.AddIPTarget(ctx, lb, opts)
+			if err != nil {
+				if hcloud.IsError(err, hcloud.ErrorCodeResourceLimitExceeded) {
+					klog.InfoS("resource limit exceeded", "err", err.Error(), "op", op, "service", svc.ObjectMeta.Name, "targetName", k8sNodeNames[id])
+					return false, nil
+				}
+				return changed, fmt.Errorf("%s: target %s: %w", op, k8sNodeNames[id], err)
+			}
+			if err := WatchAction(ctx, l.ActionClient, a); err != nil {
+				return changed, fmt.Errorf("%s: target %s: %w", op, k8sNodeNames[id], err)
+			}
+			changed = true
+		}
+	}
 	return changed, nil
 }
 
@@ -1112,24 +1210,36 @@ func (b *hclbServiceOptsBuilder) buildUpdateServiceOpts() (hcloud.LoadBalancerUp
 }
 
 // TODO this is a copy of the function in hcloud/utils.go => refactor
-func providerIDToServerID(providerID string) (int, error) {
-	const op = "hcops/providerIDToServerID"
+const (
+	providerName      = "hcloud"
+	providerNameRobot = "hetzner"
+)
 
-	providerPrefix := "hcloud://"
-	if !strings.HasPrefix(providerID, providerPrefix) {
-		return 0, fmt.Errorf("%s: missing prefix hcloud://: %s", op, providerID)
+func providerIDToServerID(providerID string) (id int, isHCloudServer bool, err error) {
+	const op = "hcloud/providerIDToServerID"
+
+	providerPrefixHCloud := providerName + "://"
+	providerPrefixRobot := providerNameRobot + "://"
+	if !strings.HasPrefix(providerID, providerPrefixHCloud) && !strings.HasPrefix(providerID, providerPrefixRobot) {
+		klog.Infof("%s: make sure your cluster configured for an external cloud provider", op)
+		return 0, false, fmt.Errorf("%s: missing prefix %s or %s. %s", providerPrefixHCloud, providerPrefixRobot, op, providerID)
 	}
 
-	idString := strings.ReplaceAll(providerID, providerPrefix, "")
+	if strings.HasPrefix(providerID, providerPrefixHCloud) {
+		isHCloudServer = true
+	}
+
+	idString := strings.ReplaceAll(providerID, providerPrefixHCloud, "")
+	idString = strings.ReplaceAll(idString, providerPrefixRobot, "")
 	if idString == "" {
-		return 0, fmt.Errorf("%s: missing serverID: %s", op, providerID)
+		return 0, false, fmt.Errorf("%s: missing serverID: %s", op, providerID)
 	}
 
-	id, err := strconv.Atoi(idString)
+	id, err = strconv.Atoi(idString)
 	if err != nil {
-		return 0, fmt.Errorf("%s: invalid serverID: %s", op, providerID)
+		return 0, false, fmt.Errorf("%s: invalid serverID: %s", op, providerID)
 	}
-	return id, nil
+	return id, isHCloudServer, nil
 }
 
 func lbAttached(lb *hcloud.LoadBalancer, nwID int) bool {

--- a/internal/hcops/testing.go
+++ b/internal/hcops/testing.go
@@ -3,10 +3,12 @@ package hcops
 import (
 	"context"
 	"math/rand"
+	"net"
 	"testing"
 
 	"github.com/hetznercloud/hcloud-cloud-controller-manager/internal/mocks"
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/syself/hrobot-go/models"
 )
 
 type LoadBalancerOpsFixture struct {
@@ -16,6 +18,7 @@ type LoadBalancerOpsFixture struct {
 	CertClient    *mocks.CertificateClient
 	ActionClient  *mocks.ActionClient
 	NetworkClient *mocks.NetworkClient
+	RobotClient   *mocks.RobotClient
 
 	LBOps *LoadBalancerOps
 
@@ -29,6 +32,7 @@ func NewLoadBalancerOpsFixture(t *testing.T) *LoadBalancerOpsFixture {
 		LBClient:      &mocks.LoadBalancerClient{},
 		CertClient:    &mocks.CertificateClient{},
 		NetworkClient: &mocks.NetworkClient{},
+		RobotClient:   &mocks.RobotClient{},
 		T:             t,
 	}
 
@@ -36,12 +40,14 @@ func NewLoadBalancerOpsFixture(t *testing.T) *LoadBalancerOpsFixture {
 	fx.LBClient.Test(t)
 	fx.CertClient.Test(t)
 	fx.NetworkClient.Test(t)
+	fx.RobotClient.Test(t)
 
 	fx.LBOps = &LoadBalancerOps{
 		LBClient:      fx.LBClient,
 		CertOps:       &CertificateOps{CertClient: fx.CertClient},
 		ActionClient:  fx.ActionClient,
 		NetworkClient: fx.NetworkClient,
+		RobotClient:   fx.RobotClient,
 	}
 
 	return fx
@@ -96,6 +102,28 @@ func (fx *LoadBalancerOpsFixture) MockRemoveServerTarget(
 	action := &hcloud.Action{ID: rand.Int()}
 	fx.LBClient.On("RemoveServerTarget", fx.Ctx, lb, s).Return(action, nil, err)
 	return action
+}
+
+func (fx *LoadBalancerOpsFixture) MockAddIPTarget(
+	lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddIPTargetOpts, err error,
+) *hcloud.Action {
+	action := &hcloud.Action{ID: rand.Int()}
+	fx.LBClient.On("AddIPTarget", fx.Ctx, lb, opts).Return(action, nil, err)
+	return action
+}
+
+func (fx *LoadBalancerOpsFixture) MockRemoveIPTarget(
+	lb *hcloud.LoadBalancer, ip net.IP, err error,
+) *hcloud.Action {
+	action := &hcloud.Action{ID: rand.Int()}
+	fx.LBClient.On("RemoveIPTarget", fx.Ctx, lb, ip).Return(action, nil, err)
+	return action
+}
+
+func (fx *LoadBalancerOpsFixture) MockListRobotServers(
+	serverList []models.Server, err error,
+) {
+	fx.RobotClient.On("ServerGetList").Return(serverList, err)
 }
 
 func (fx *LoadBalancerOpsFixture) MockWatchProgress(a *hcloud.Action, err error) {

--- a/internal/mocks/casts.go
+++ b/internal/mocks/casts.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/stretchr/testify/mock"
+	"github.com/syself/hrobot-go/models"
 )
 
 func getResponsePtr(args mock.Arguments, i int) *hcloud.Response {
@@ -35,6 +36,14 @@ func getLoadBalancerPtrS(args mock.Arguments, i int) []*hcloud.LoadBalancer {
 		return nil
 	}
 	return v.([]*hcloud.LoadBalancer)
+}
+
+func getRobotServers(args mock.Arguments, i int) []models.Server {
+	v := args.Get(i)
+	if v == nil {
+		return nil
+	}
+	return v.([]models.Server)
 }
 
 func getNetworkPtr(args mock.Arguments, i int) *hcloud.Network {

--- a/internal/mocks/loadbalancer.go
+++ b/internal/mocks/loadbalancer.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"net"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/stretchr/testify/mock"
@@ -79,6 +80,18 @@ func (m *LoadBalancerClient) AddServerTarget(
 
 func (m *LoadBalancerClient) RemoveServerTarget(ctx context.Context, lb *hcloud.LoadBalancer, server *hcloud.Server) (*hcloud.Action, *hcloud.Response, error) {
 	args := m.Called(ctx, lb, server)
+	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
+func (m *LoadBalancerClient) AddIPTarget(
+	ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddIPTargetOpts,
+) (*hcloud.Action, *hcloud.Response, error) {
+	args := m.Called(ctx, lb, opts)
+	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
+}
+
+func (m *LoadBalancerClient) RemoveIPTarget(ctx context.Context, lb *hcloud.LoadBalancer, ip net.IP) (*hcloud.Action, *hcloud.Response, error) {
+	args := m.Called(ctx, lb, ip)
 	return getActionPtr(args, 0), getResponsePtr(args, 1), args.Error(2)
 }
 

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -1,0 +1,82 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/syself/hrobot-go/models"
+)
+
+type RobotClient struct {
+	mock.Mock
+}
+
+func (m *RobotClient) ServerGetList() ([]models.Server, error) {
+	args := m.Called()
+	return getRobotServers(args, 0), args.Error(1)
+}
+
+func (m *RobotClient) BootLinuxDelete(id int) (*models.Linux, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) BootLinuxGet(id int) (*models.Linux, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) BootLinuxSet(id int, input *models.LinuxSetInput) (*models.Linux, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) BootRescueDelete(id int) (*models.Rescue, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) BootRescueGet(id int) (*models.Rescue, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) BootRescueSet(id int, input *models.RescueSetInput) (*models.Rescue, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) FailoverGet(ip string) (*models.Failover, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) FailoverGetList() ([]models.Failover, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) GetVersion() string {
+	panic("this method should not be called")
+}
+func (m *RobotClient) IPGetList() ([]models.IP, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) KeyGetList() ([]models.Key, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) KeySet(input *models.KeySetInput) (*models.Key, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) RDnsGet(ip string) (*models.Rdns, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) RDnsGetList() ([]models.Rdns, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ResetGet(id int) (*models.Reset, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ResetSet(id int, input *models.ResetSetInput) (*models.ResetPost, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ServerGet(id int) (*models.Server, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ServerReverse(id int) (*models.Cancellation, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ServerSetName(id int, input *models.ServerSetNameInput) (*models.Server, error) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) SetBaseURL(baseURL string) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) SetUserAgent(userAgent string) {
+	panic("this method should not be called")
+}
+func (m *RobotClient) ValidateCredentials() error {
+	panic("this method should not be called")
+}


### PR DESCRIPTION
Add support for Hetzner dedicated servers:
- Add client for robot API
- Reconcile dedicated servers as targets of Load balancer
- Give information to cloud provider about K8s nodes based on Hetzner dedicated servers