### PR TITLE
Support local network (vSwitch).

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -1,0 +1,20 @@
+package hcloud
+
+import (
+	hcloud "github.com/hetznercloud/hcloud-go/hcloud"
+	hrobot "github.com/syself/hrobot-go"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type client struct {
+	cloudClient *hcloud.Client
+	robotClient hrobot.RobotClient
+	kubernetes  clientset.Interface
+}
+
+func newClient(hcloud *hcloud.Client, robotClient hrobot.RobotClient) *client {
+	return &client{
+		cloudClient: hcloud,
+		robotClient: robotClient,
+	}
+}

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -30,6 +30,7 @@ import (
 	"github.com/syself/hetzner-cloud-controller-manager/internal/hcops"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/metrics"
 	hrobot "github.com/syself/hrobot-go"
+
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 )
@@ -65,8 +66,7 @@ var (
 )
 
 type cloud struct {
-	client       *hcloud.Client
-	robotClient  hrobot.RobotClient
+	client       *client
 	instances    *instances
 	zones        *zones
 	routes       *routes
@@ -108,7 +108,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 	if endpoint := os.Getenv(hcloudEndpointENVVar); endpoint != "" {
 		opts = append(opts, hcloud.WithEndpoint(endpoint))
 	}
-	client := hcloud.NewClient(opts...)
+	cloudClient := hcloud.NewClient(opts...)
 	metadataClient := metadata.NewClient()
 
 	robotUserName, foundRobotUserName := os.LookupEnv(robotUserNameENVVar)
@@ -119,9 +119,11 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		robotClient = hrobot.NewBasicAuthClient(robotUserName, robotPassword)
 	}
 
+	client := newClient(cloudClient, robotClient)
+
 	var networkID int
 	if v, ok := os.LookupEnv(hcloudNetworkENVVar); ok {
-		n, _, err := client.Network.Get(context.Background(), v)
+		n, _, err := client.cloudClient.Network.Get(context.Background(), v)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
@@ -148,7 +150,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 		klog.Infof("%s: %s empty", op, hcloudNetworkENVVar)
 	}
 
-	_, _, err := client.Server.List(context.Background(), hcloud.ServerListOpts{})
+	_, _, err := client.cloudClient.Server.List(context.Background(), hcloud.ServerListOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
@@ -161,16 +163,16 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 	klog.Infof("Hetzner Cloud k8s cloud controller %s started\n", providerVersion)
 
 	lbOps := &hcops.LoadBalancerOps{
-		LBClient:      &client.LoadBalancer,
-		CertOps:       &hcops.CertificateOps{CertClient: &client.Certificate},
-		ActionClient:  &client.Action,
-		NetworkClient: &client.Network,
+		LBClient:      &client.cloudClient.LoadBalancer,
+		CertOps:       &hcops.CertificateOps{CertClient: &client.cloudClient.Certificate},
+		ActionClient:  &client.cloudClient.Action,
+		NetworkClient: &client.cloudClient.Network,
 		RobotClient:   robotClient,
 		NetworkID:     networkID,
 		Defaults:      lbOpsDefaults,
 	}
 
-	loadBalancers := newLoadBalancers(lbOps, &client.Action, lbDisablePrivateIngress, lbDisableIPv6)
+	loadBalancers := newLoadBalancers(lbOps, &client.cloudClient.Action, lbDisablePrivateIngress, lbDisableIPv6)
 	if os.Getenv(hcloudLoadBalancersEnabledENVVar) == "false" {
 		loadBalancers = nil
 	}
@@ -182,9 +184,8 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 
 	return &cloud{
 		client:       client,
-		robotClient:  robotClient,
-		zones:        newZones(client, robotClient, nodeName),
-		instances:    newInstances(client, robotClient, instancesAddressFamily),
+		zones:        newZones(client.cloudClient, robotClient, nodeName),
+		instances:    newInstances(client, instancesAddressFamily),
 		loadBalancer: loadBalancers,
 		routes:       nil,
 		networkID:    networkID,
@@ -192,6 +193,9 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 }
 
 func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+	c.client.kubernetes = clientBuilder.ClientOrDie("cloud-controller-manager")
+
+	klog.Infof("clientset initialized")
 }
 
 func (c *cloud) Instances() (cloudprovider.Instances, bool) {
@@ -221,7 +225,7 @@ func (c *cloud) Clusters() (cloudprovider.Clusters, bool) {
 
 func (c *cloud) Routes() (cloudprovider.Routes, bool) {
 	if c.networkID > 0 {
-		r, err := newRoutes(c.client, c.networkID)
+		r, err := newRoutes(c.client.cloudClient, c.networkID)
 		if err != nil {
 			klog.ErrorS(err, "create routes provider", "networkID", c.networkID)
 			return nil, false

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -60,7 +60,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	addr, err := instances.NodeAddressesByProviderID(context.TODO(), "hcloud://1")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -120,7 +120,7 @@ func TestNodeAddresses(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	addr, err := instances.NodeAddresses(context.TODO(), "node15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -180,7 +180,7 @@ func TestNodeAddressesIPv6(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv6)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv6)
 	addr, err := instances.NodeAddresses(context.TODO(), "node15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -240,7 +240,7 @@ func TestNodeAddressesDualStack(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyDualStack)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyDualStack)
 	addr, err := instances.NodeAddresses(context.TODO(), "node15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -291,7 +291,7 @@ func TestExternalID(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	id, err := instances.ExternalID(context.TODO(), "node15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -340,7 +340,7 @@ func TestInstanceType(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	serverType, err := instances.InstanceType(context.TODO(), "node15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -383,7 +383,7 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 		})
 	})
 
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	instanceType, err := instances.InstanceTypeByProviderID(context.TODO(), "hcloud://1")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -427,7 +427,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		exists, err := instances.InstanceExistsByProviderID(context.TODO(), "hcloud://1")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -468,7 +468,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		exists, err := instances.InstanceExistsByProviderID(context.TODO(), "hcloud://1")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -501,7 +501,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		exists, err := instances.InstanceExistsByProviderID(context.TODO(), "hcloud://bm-1")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -536,7 +536,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		isOff, err := instances.InstanceShutdownByProviderID(context.TODO(), "hcloud://1")
 		if !isOff {
 			t.Errorf("Unexpected isOff state: %v", isOff)
@@ -567,7 +567,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		isOff, err := instances.InstanceShutdownByProviderID(context.TODO(), "hcloud://1")
 		if isOff {
 			t.Errorf("Unexpected isOff state: %v", isOff)
@@ -591,7 +591,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 			})
 		})
 
-		instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+		instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 		isOff, err := instances.InstanceShutdownByProviderID(context.TODO(), "hcloud://bm-1")
 		if isOff {
 			t.Errorf("Unexpected isOff state: %v", isOff)
@@ -605,7 +605,7 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 func TestCurrentNodeName(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()
-	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4)
+	instances := newInstances(newClient(env.Client, env.RobotClient), AddressFamilyIPv4)
 	nodeName, err := instances.CurrentNodeName(context.TODO(), "hostname")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Hello.

This change helps to use baremetal servers (robot) with local network (vSwitch). It adds local ip address (kubelet AnnotationProvidedIPAddr) to the node.

Full conversation you can find here #6 