### PR TITLE
Supporting taint node.cluster.x-k8s.io/uninitialized

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hetzner-cloud-controller-manager
 type: application
-version: v1.13.2
+version: v1.13.3

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        # Introduced with CAPI v1.4, more info: https://cluster-api.sigs.k8s.io/developer/providers/bootstrap.html#taint-nodes-at-creation
+        - key: "node.cluster.x-k8s.io/uninitialized"
+          effect: "NoSchedule"
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
           effect: "NoSchedule"

--- a/deploy/ccm.yaml
+++ b/deploy/ccm.yaml
@@ -41,6 +41,10 @@ spec:
       dnsPolicy: Default
       tolerations:
         # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        # Introduced with CAPI v1.4, more info: https://cluster-api.sigs.k8s.io/developer/providers/bootstrap.html#taint-nodes-at-creation
+        - key: "node.cluster.x-k8s.io/uninitialized"
+          effect: "NoSchedule"
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
           effect: "NoSchedule"


### PR DESCRIPTION
Closes #12.