### PR TITLE
:bug: New rate limit handling for robot API

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -43,6 +43,10 @@ const (
 	robotUserNameENVVar = "ROBOT_USER_NAME"
 	robotPasswordENVVar = "ROBOT_PASSWORD"
 
+	// Only as reference - is used in hcops package.
+	// Default is 5 minutes.
+	RateLimitWaitTimeRobot = "RATE_LIMIT_WAIT_TIME_ROBOT"
+
 	// Disable the "master/server is attached to the network" check against the metadata service.
 	hcloudNetworkDisableAttachedCheckENVVar  = "HCLOUD_NETWORK_DISABLE_ATTACHED_CHECK"
 	hcloudNetworkRoutesEnabledENVVar         = "HCLOUD_NETWORK_ROUTES_ENABLED"

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -624,6 +624,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 	// correspond to a dedicated server
 	dedicatedServers, err := l.RobotClient.ServerGetList()
 	if err != nil {
+		HandleRateLimitExceededError(err)
 		return changed, fmt.Errorf("%s: failed to get list of dedicated servers: %w", op, err)
 	}
 

--- a/internal/hcops/ratelimit.go
+++ b/internal/hcops/ratelimit.go
@@ -1,0 +1,96 @@
+package hcops
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/syself/hrobot-go/models"
+)
+
+func init() {
+	rateLimitWaitTimeRobot, err := getEnvDuration("RATE_LIMIT_WAIT_TIME_ROBOT")
+	if err != nil {
+		panic(err)
+	}
+
+	if rateLimitWaitTimeRobot == 0 {
+		rateLimitWaitTimeRobot = 5 * time.Minute
+	}
+
+	handler = rateLimitHandler{
+		waitTime: rateLimitWaitTimeRobot,
+	}
+}
+
+var handler rateLimitHandler
+
+type rateLimitHandler struct {
+	waitTime    time.Duration
+	exceeded    bool
+	lastChecked time.Time
+}
+
+func (rl *rateLimitHandler) set() {
+	rl.exceeded = true
+	rl.lastChecked = time.Now()
+}
+
+func (rl *rateLimitHandler) isExceeded() bool {
+	if !rl.exceeded {
+		return false
+	}
+
+	if time.Now().Before(rl.lastChecked.Add(rl.waitTime)) {
+		return true
+	}
+	// Waiting time is over. Should try again
+	rl.exceeded = false
+	rl.lastChecked = time.Time{}
+	return false
+}
+
+func (rl *rateLimitHandler) timeOfNextPossibleAPICall() time.Time {
+	emptyTime := time.Time{}
+	if rl.lastChecked == emptyTime {
+		return emptyTime
+	}
+	return rl.lastChecked.Add(rl.waitTime)
+}
+
+// implement rate limit that is stored in memory
+
+func IsRateLimitExceeded() bool {
+	return handler.isExceeded()
+}
+
+func SetRateLimit() {
+	handler.set()
+}
+
+func TimeOfNextPossibleAPICall() time.Time {
+	return handler.timeOfNextPossibleAPICall()
+}
+
+func HandleRateLimitExceededError(err error) {
+	if models.IsError(err, models.ErrorCodeRateLimitExceeded) || strings.Contains(err.Error(), "server responded with status code 403") {
+		SetRateLimit()
+	}
+}
+
+// getEnvDuration returns the duration parsed from the environment variable with the given key and a potential error
+// parsing the var. Returns false if the env var is unset.
+func getEnvDuration(key string) (time.Duration, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0, nil
+	}
+
+	b, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %v", key, err)
+	}
+
+	return b, nil
+}

--- a/internal/hcops/ratelimit_test.go
+++ b/internal/hcops/ratelimit_test.go
@@ -1,4 +1,4 @@
-package hcloud
+package hcops
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRateLimitSet(t *testing.T) {
-	rl := rateLimit{}
+	rl := rateLimitHandler{}
 	now := time.Now()
 	rl.set()
 	require.Equal(t, true, rl.exceeded)
@@ -19,18 +19,18 @@ func TestRateLimitSet(t *testing.T) {
 func TestRateLimitIsExceeded(t *testing.T) {
 	now := time.Now()
 
-	rateLimitNotExceeded := rateLimit{}
+	rateLimitNotExceeded := rateLimitHandler{}
 
 	require.Equal(t, false, rateLimitNotExceeded.isExceeded())
 
-	rateLimitExceeded := rateLimit{
+	rateLimitExceeded := rateLimitHandler{
 		exceeded:    true,
 		lastChecked: now.Add(-3 * time.Minute),
 	}
 
 	require.Equal(t, true, rateLimitExceeded.isExceeded())
 
-	rateLimitWaitingTimeOver := rateLimit{
+	rateLimitWaitingTimeOver := rateLimitHandler{
 		exceeded:    true,
 		lastChecked: now.Add(-10 * time.Minute),
 	}
@@ -43,14 +43,15 @@ func TestRateLimitIsExceeded(t *testing.T) {
 func TestRateLimitTimeOfNextPossibleAPICall(t *testing.T) {
 	now := time.Now()
 	lastChecked := now.Add(-3 * time.Minute)
-	rateLimitExceeded := rateLimit{
+	rateLimitExceeded := rateLimitHandler{
+		waitTime:    5 * time.Minute,
 		exceeded:    true,
 		lastChecked: lastChecked,
 	}
 
-	require.Equal(t, lastChecked.Add(rateLimitWaitingTime), rateLimitExceeded.timeOfNextPossibleAPICall())
+	require.Equal(t, lastChecked.Add(rateLimitExceeded.waitTime), rateLimitExceeded.timeOfNextPossibleAPICall())
 
-	rateLimitNotExceeded := rateLimit{}
+	rateLimitNotExceeded := rateLimitHandler{}
 
 	require.Equal(t, time.Time{}, rateLimitNotExceeded.timeOfNextPossibleAPICall())
 }


### PR DESCRIPTION
New rate limit handling fixing various bugs/shortcomings:
- the robot "server" endpoint does not differentiate list and get calls and counts everything together for one rate limit. We deal with that accordingly
- we didn't have rate limit handling for the loadbalancer target reconciling.
- we hard-coded the duration we wait until next trying the API call. Now it is an environment variable