### PR TITLE
:seedling: use old Entrypoint (/bin/hetzner-cloud-controller-manager)

### DIFF
--- a/images/hetzner-cloud-controller-manager/Dockerfile
+++ b/images/hetzner-cloud-controller-manager/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go/pkg \
 
 FROM --platform=${BUILDPLATFORM} gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=build /src/hetzner-cloud-controller-manager/manager .
+COPY --from=build /src/hetzner-cloud-controller-manager/manager /bin/hetzner-cloud-controller-manager
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 USER 65532
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/bin/hetzner-cloud-controller-manager"]


### PR DESCRIPTION
we don't want to break existing deployments.