### PR TITLE
:bug: Fix InstanceExists for baremetal servers

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -57,7 +57,7 @@ const (
 	// Default is 5 minutes.
 	RateLimitWaitTimeRobot = "RATE_LIMIT_WAIT_TIME_ROBOT"
 
-	// default is 3 minutes.
+	// default is 5 minutes.
 	CacheTimeout = "CACHE_TIMEOUT"
 
 	// Disable the "master/server is attached to the network" check against the metadata service.
@@ -98,7 +98,6 @@ type LoggingTransport struct {
 var replaceHex = regexp.MustCompile(`0x[0123456789abcdef]+`)
 
 func (lt *LoggingTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-
 	stack := replaceHex.ReplaceAllString(string(debug.Stack()), "0xX")
 	stack = strings.ReplaceAll(stack, "\n", "\\n")
 
@@ -157,7 +156,7 @@ func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
 	}
 
 	if cacheTimeout == 0 {
-		cacheTimeout = 3 * time.Minute
+		cacheTimeout = 5 * time.Minute
 	}
 
 	var robotClient robotclient.Client

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -94,7 +94,6 @@ func (i *instances) lookupServer(
 			}
 		}
 	}
-
 	return hcloudServer, bmServer, isHCloudServer, nil
 }
 
@@ -113,6 +112,7 @@ func (i *instances) InstanceExists(ctx context.Context, node *corev1.Node) (bool
 func (i *instances) InstanceShutdown(ctx context.Context, node *corev1.Node) (bool, error) {
 	const op = "hcloud/instancesv2.InstanceShutdown"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
+
 	hcloudServer, _, isHCloudServer, err := i.lookupServer(ctx, node)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", op, err)

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -99,6 +99,11 @@ func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (*model
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
+	// check whether name matches - otherwise this server does not belong to the respective node anymore
+	if server.Name != node.Name {
+		return nil, nil
+	}
+
 	// return nil, nil if server could not be found
 	return server, nil
 }

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -29,15 +29,22 @@ func NewClient(robotClient hrobot.RobotClient, cacheTimeout time.Duration) clien
 
 func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 	if c.shouldSync() {
-		server, err := c.robotClient.ServerGet(id)
+		list, err := c.robotClient.ServerGetList()
 		if err != nil {
-			return server, err
+			return nil, err
 		}
 
-		// Add server to cache in case there is another Get call - but do not update time of last update.
-		// That only makes sense for list calls.
-		c.m[server.ServerNumber] = server
-		return server, nil
+		// populate list
+		c.l = list
+
+		// remove all entries from map and populate it freshly
+		c.m = make(map[int]*models.Server)
+		for i, server := range list {
+			c.m[server.ServerNumber] = &list[i]
+		}
+
+		// set time of last update
+		c.lastUpdate = time.Now()
 	}
 
 	server, found := c.m[id]


### PR DESCRIPTION
Fixing the InstanceExists function for bare metal servers. The endpoint
did not check whether the node name matches and therefore always returns
that a certain bare metal instance exists, as these servers are treated
as pet and do not get removed from the system, as is the case for HCloud servers.

Furthermore, this commit changes the caching behavior to never call the
API for individual servers. This was not needed for InstanceV1
interface, as it worked with node names more often than providerIDs
which led to list calls of robot API anyway. This is not the case in
InstanceV2, where almost all the time get calls are used. These calls
can be cached by an occasional list call as we do now.