### PR TITLE
:bug: Fix getInstanceTypeOfRobotServer: convert invalid characters to dashes

### DIFF
--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -19,6 +19,7 @@ package hcloud
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -156,7 +157,16 @@ func getInstanceTypeOfRobotServer(bmServer *models.Server) string {
 	if bmServer == nil {
 		panic("getInstanceTypeOfRobotServer called with nil server")
 	}
-	return strings.ReplaceAll(bmServer.Product, " ", "-")
+	return stringToLabelValue(bmServer.Product)
+}
+
+var stringToLabelValueRegex = regexp.MustCompile(`[^a-zA-Z0-9_.]+`)
+
+func stringToLabelValue(s string) string {
+	s = stringToLabelValueRegex.ReplaceAllString(s, "-")
+	trimChars := "_.-"
+	s = strings.Trim(s, trimChars)
+	return s
 }
 
 func getZoneOfRobotServer(bmServer *models.Server) string {

--- a/hcloud/util_test.go
+++ b/hcloud/util_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Hetzner Cloud GmbH.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hcloud
+
+import (
+	"testing"
+)
+
+func Test_stringToLabelValue(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"üaü", "a"},
+		{"   Foo - - Power™  ", "Foo-Power"},
+		{"üa--./_", "a"},
+	}
+	for _, tt := range tests {
+		actual := stringToLabelValue(tt.in)
+		if actual != tt.want {
+			t.Errorf("stringToLabelValue(%q) = %q, want %q", tt.in, actual, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
getInstanceTypeOfRobotServer() could fail for strings like "Dell PowerEdge™", because the TM-symbol is not allowed in Kubernetes label values.

Fixes #38 

Thank you, @sasho4ek07, for the bug report and initial PR.