### PR TITLE
🌱 separate user agent from HCCM

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -129,7 +129,7 @@ func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
 
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(token),
-		hcloud.WithApplication("hcloud-cloud-controller", providerVersion),
+		hcloud.WithApplication("hetzner-cloud-controller", providerVersion),
 	}
 
 	// start metrics server if enabled (enabled by default)

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -62,7 +62,7 @@ func (tc *TestCluster) Start() error {
 
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(token),
-		hcloud.WithApplication("hcloud-ccm-testsuite", "1.0"),
+		hcloud.WithApplication("hetzner-ccm-testsuite", "1.0"),
 	}
 	hcloudClient := hcloud.NewClient(opts...)
 	tc.hcloud = hcloudClient


### PR DESCRIPTION
Replace the user agent of `hcloud-go` to be something else than the hcloud-cloud-controller-manager user agent. This helps us figure out what integrations a user has deployed when they need support.