### PR TITLE
:seedling: Fix tests.

### DIFF
--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -54,7 +54,6 @@ func newTestEnv() testEnv {
 		hcloud.WithEndpoint(server.URL),
 		hcloud.WithToken("jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jNZXCeTYQ4uArypFM3nh75"),
 		hcloud.WithBackoffFunc(func(_ int) time.Duration { return 0 }),
-		// hcloud.WithDebugWriter(os.Stdout),
 	)
 	robotClient := hrobot.NewBasicAuthClient("", "")
 	robotClient.SetBaseURL(server.URL + "/robot")

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -54,7 +54,7 @@ func newTestEnv() testEnv {
 		hcloud.WithEndpoint(server.URL),
 		hcloud.WithToken("jr5g7ZHpPptyhJzZyHw2Pqu4g9gTqDvEceYpngPf79jNZXCeTYQ4uArypFM3nh75"),
 		hcloud.WithBackoffFunc(func(_ int) time.Duration { return 0 }),
-		hcloud.WithDebugWriter(os.Stdout),
+		// hcloud.WithDebugWriter(os.Stdout),
 	)
 	robotClient := hrobot.NewBasicAuthClient("", "")
 	robotClient.SetBaseURL(server.URL + "/robot")

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -229,6 +229,9 @@ func TestInstances_InstanceShutdown(t *testing.T) {
 			name: "bm server",
 			node: &corev1.Node{
 				Spec: corev1.NodeSpec{ProviderID: "hcloud://bm-321"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bm-server1",
+				},
 			},
 			expected: false,
 		},
@@ -313,6 +316,9 @@ func TestInstances_InstanceMetadataRobotServer(t *testing.T) {
 	instances := newInstances(env.Client, env.RobotClient, AddressFamilyIPv4, 0)
 
 	metadata, err := instances.InstanceMetadata(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bm-server1",
+		},
 		Spec: corev1.NodeSpec{ProviderID: "hcloud://bm-321"},
 	})
 	if err != nil {

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -104,6 +104,9 @@ func TestInstances_InstanceExists(t *testing.T) {
 		}, {
 			name: "existing robot server by id",
 			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bm-server1",
+				},
 				Spec: corev1.NodeSpec{ProviderID: "hcloud://bm-321"},
 			},
 			expected: true,
@@ -116,6 +119,9 @@ func TestInstances_InstanceExists(t *testing.T) {
 		}, {
 			name: "missing robot server by id",
 			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bm-server2",
+				},
 				Spec: corev1.NodeSpec{ProviderID: "hcloud://bm-322"},
 			},
 			expected: false,

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -98,15 +98,15 @@ func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *mod
 	}
 
 	server, err := c.ServerGet(id)
-	if err != nil && !models.IsError(err, models.ErrorCodeServerNotFound) {
+	if models.IsError(err, models.ErrorCodeServerNotFound) {
+		return nil, nil
+	}
+	if err != nil {
 		hcops.HandleRateLimitExceededError(err, node)
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	// check whether name matches - otherwise this server does not belong to the respective node anymore
-	if server == nil {
-		return nil, nil
-	}
 	if server.Name != node.Name {
 		return nil, nil
 	}

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -85,10 +84,6 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 
 func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *models.Server, e error) {
 	const op = "robot/getServerByID"
-	defer func() {
-		fmt.Printf("---------- id %v\nname: %q %+v\nout server %+v\nout err: %+v\n%s\n\n", id, node.Name, node, s, e, string(debug.Stack()))
-	}()
-
 	if node.Name == "" {
 		return nil, fmt.Errorf("%s: node name is empty", op)
 	}
@@ -113,7 +108,6 @@ func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *mod
 		return nil, nil
 	}
 	if server.Name != node.Name {
-		fmt.Printf("----------------- name diff server %q node %q\n", server.Name, node.Name)
 		return nil, nil
 	}
 

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -728,8 +728,6 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		if hclbTargetIDs[id] {
 			continue
 		}
-		fmt.Println(lb)
-		fmt.Printf("+++ %+v\n", lb)
 		if lb.LoadBalancerType != nil && maxTargetsReached(numberOfTargets, lb.LoadBalancerType.Name) {
 			l.Recorder.Eventf(
 				svc,

--- a/internal/hcops/load_balancer.go
+++ b/internal/hcops/load_balancer.go
@@ -728,8 +728,9 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 		if hclbTargetIDs[id] {
 			continue
 		}
-
-		if maxTargetsReached(numberOfTargets, lb.LoadBalancerType.Name) {
+		fmt.Println(lb)
+		fmt.Printf("+++ %+v\n", lb)
+		if lb.LoadBalancerType != nil && maxTargetsReached(numberOfTargets, lb.LoadBalancerType.Name) {
 			l.Recorder.Eventf(
 				svc,
 				"Warning",
@@ -785,7 +786,7 @@ func (l *LoadBalancerOps) ReconcileHCLBTargets(
 				continue
 			}
 
-			if maxTargetsReached(numberOfTargets, lb.LoadBalancerType.Name) {
+			if lb.LoadBalancerType != nil && maxTargetsReached(numberOfTargets, lb.LoadBalancerType.Name) {
 				l.Recorder.Eventf(
 					svc,
 					"Warning",

--- a/internal/hcops/ratelimit_test.go
+++ b/internal/hcops/ratelimit_test.go
@@ -26,6 +26,7 @@ func TestRateLimitIsExceeded(t *testing.T) {
 	rateLimitExceeded := rateLimitHandler{
 		exceeded:    true,
 		lastChecked: now.Add(-3 * time.Minute),
+		waitTime:    5 * time.Minute,
 	}
 
 	require.Equal(t, true, rateLimitExceeded.isExceeded())

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,6 +22,8 @@ import (
 var testCluster TestCluster
 
 func TestMain(m *testing.M) {
+	fmt.Printf("the e2e tests seem to require a special setup. They are disabled in our fork.\n")
+	os.Exit(1)
 	if err := testCluster.Start(); err != nil {
 		fmt.Printf("testCluster.Start failed: %v\n", err)
 		os.Exit(1)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -23,14 +23,14 @@ var testCluster TestCluster
 
 func TestMain(m *testing.M) {
 	if err := testCluster.Start(); err != nil {
-		fmt.Printf("%v\n", err)
+		fmt.Printf("testCluster.Start failed: %v\n", err)
 		os.Exit(1)
 	}
 
 	rc := m.Run()
 
 	if err := testCluster.Stop(); err != nil {
-		fmt.Printf("%v\n", err)
+		fmt.Printf("testCluster.Stop failed: %v\n", err)
 		os.Exit(1)
 	}
 	os.Exit(rc)

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -51,7 +51,7 @@ func (tc *TestCluster) Start() error {
 	if token == "" {
 		buf, err := os.ReadFile(fmt.Sprintf("../../hack/.token-%s", tc.scope))
 		if err != nil {
-			return err
+			return fmt.Errorf("HCLOUD_TOKEN not set and no token file found: %w", err)
 		}
 		token = string(buf)
 	}
@@ -67,10 +67,10 @@ func (tc *TestCluster) Start() error {
 	hcloudClient := hcloud.NewClient(opts...)
 	tc.hcloud = hcloudClient
 
-	err := os.Setenv("KUBECONFIG", "../../hack/.kubeconfig-"+tc.scope)
-	if err != nil {
-		return err
-	}
+	// err := os.Setenv("KUBECONFIG", "../../hack/.kubeconfig-"+tc.scope)
+	// if err != nil {
+	// 	return err
+	// }
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}

--- a/tests/e2e/testing.go
+++ b/tests/e2e/testing.go
@@ -67,6 +67,8 @@ func (tc *TestCluster) Start() error {
 	hcloudClient := hcloud.NewClient(opts...)
 	tc.hcloud = hcloudClient
 
+	// Syself: the e2e tests seem to require a special environment.
+	// I tried it with a kind cluster, but this did not work.
 	// err := os.Setenv("KUBECONFIG", "../../hack/.kubeconfig-"+tc.scope)
 	// if err != nil {
 	// 	return err


### PR DESCRIPTION
Fix tests.

Up to now, they failed like this:

```
❯ go test ./...
?       github.com/syself/hetzner-cloud-controller-manager      [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/metrics     [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/mocks       [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/robot/client        [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/robot/client/cache  [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/testsupport [no test files]
?       github.com/syself/hetzner-cloud-controller-manager/internal/util        [no test files]
I1212 11:51:24.314196 3137547 cloud.go:180] Hetzner robot is not support because of insufficient credentials. Robot user name specified: false. Robot password specified: false
I1212 11:51:24.314263 3137547 cloud.go:209] hcloud/newCloud: HCLOUD_NETWORK empty
I1212 11:51:24.314879 3137547 cloud.go:223] Hetzner Cloud k8s cloud controller unknown started
I1212 11:51:24.315038 3137547 cloud.go:180] Hetzner robot is not support because of insufficient credentials. Robot user name specified: false. Robot password specified: false
I1212 11:51:24.315048 3137547 cloud.go:209] hcloud/newCloud: HCLOUD_NETWORK empty
I1212 11:51:24.315196 3137547 cloud.go:180] Hetzner robot is not support because of insufficient credentials. Robot user name specified: false. Robot password specified: false
I1212 11:51:24.315205 3137547 cloud.go:209] hcloud/newCloud: HCLOUD_NETWORK empty
I1212 11:51:24.315636 3137547 cloud.go:176] Not enabling robot API debugging. Set env var ROBOT_DEBUG=true to enable it.
I1212 11:51:24.315645 3137547 cloud.go:209] hcloud/newCloud: HCLOUD_NETWORK empty
I1212 11:51:24.315938 3137547 cloud.go:223] Hetzner Cloud k8s cloud controller unknown started
I1212 11:51:24.316051 3137547 cloud.go:176] Not enabling robot API debugging. Set env var ROBOT_DEBUG=true to enable it.
I1212 11:51:24.316342 3137547 cloud.go:223] Hetzner Cloud k8s cloud controller unknown started
--- Request:
GET /servers/1 HTTP/1.1
Host: 127.0.0.1:34743
User-Agent: hcloud-go/2.2.0
Authorization: REDACTED
Accept-Encoding: gzip



--- Response:
HTTP/1.1 200 OK
Content-Length: 930
Content-Type: text/plain; charset=utf-8
Date: Thu, 12 Dec 2024 10:51:24 GMT

{"server":{"id":1,"name":"foobar","status":"","created":"0001-01-01T00:00:00Z","public_net":{"ipv4":{"id":0,"ip":"","blocked":false,"dns_ptr":""},"ipv6":{"id":0,"ip":"","blocked":false,"dns_ptr":null},"floating_ips":null,"firewalls":null},"private_net":null,"server_type":{"id":0,"name":"","description":"","cores":0,"memory":0,"disk":0,"storage_type":"","cpu_type":"","architecture":"","included_traffic":0,"prices":null,"deprecation":null},"included_traffic":0,"outgoing_traffic":null,"ingoing_traffic":null,"backup_window":null,"rescue_enabled":false,"iso":null,"locked":false,"datacenter":{"id":0,"name":"","description":"","location":{"id":0,"name":"","description":"","country":"","city":"","latitude":0,"longitude":0,"network_zone":""},"server_types":{"supported":null,"available":null}},"image":null,"protection":{"delete":false,"rebuild":false},"labels":null,"volumes":null,"primary_disk_size":0,"placement_group":null}}


--- Request:
GET /servers/2 HTTP/1.1
Host: 127.0.0.1:34743
User-Agent: hcloud-go/2.2.0
Authorization: REDACTED
Accept-Encoding: gzip



--- Response:
HTTP/1.1 404 Not Found
Content-Length: 74
Content-Type: application/json
Date: Thu, 12 Dec 2024 10:51:24 GMT

{"error":{"code":"not_found","message":"","details":null,"Details":null}}


--- FAIL: TestInstances_InstanceExists (0.00s)
    --- FAIL: TestInstances_InstanceExists/existing_robot_server_by_id (0.00s)
        instances_test.go:164: Expected server to exist true but got false
    --- FAIL: TestInstances_InstanceExists/missing_robot_server_by_id (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1503ede]

goroutine 73 [running]:
testing.tRunner.func1.2({0x16d6d80, 0x2785670})
        /usr/local/go/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1635 +0x35e
panic({0x16d6d80?, 0x2785670?})
        /usr/local/go/src/runtime/panic.go:785 +0x132
github.com/syself/hetzner-cloud-controller-manager/hcloud.getRobotServerByID({0x702989a582d8, 0xc0003ce820}, 0x142, 0xc0005b2f08)
        /home/guettli/syself/hccm2/hcloud/util.go:104 +0x19e
github.com/syself/hetzner-cloud-controller-manager/hcloud.(*instances).lookupServer(0xc0005aaf60, {0x1b76f18, 0x27d45c0}, 0xc0005b2f08)
        /home/guettli/syself/hccm2/hcloud/instances.go:75 +0x2d4
github.com/syself/hetzner-cloud-controller-manager/hcloud.(*instances).InstanceExists(0xc0005aaf60, {0x1b76f18, 0x27d45c0}, 0xc0005b2f08)
        /home/guettli/syself/hccm2/hcloud/instances.go:104 +0x85
github.com/syself/hetzner-cloud-controller-manager/hcloud.TestInstances_InstanceExists.func7(0xc0000e41a0)
        /home/guettli/syself/hccm2/hcloud/instances_test.go:159 +0x45
testing.tRunner(0xc0000e41a0, 0xc0002f8180)
        /usr/local/go/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 63
        /usr/local/go/src/testing/testing.go:1743 +0x390
FAIL    github.com/syself/hetzner-cloud-controller-manager/hcloud       0.017s
ok      github.com/syself/hetzner-cloud-controller-manager/internal/annotation  0.005s
--- FAIL: TestRateLimitIsExceeded (0.00s)
    ratelimit_test.go:31:
                Error Trace:    /home/guettli/syself/hccm2/internal/hcops/ratelimit_test.go:31
                Error:          Not equal:
                                expected: true
                                actual  : false
                Test:           TestRateLimitIsExceeded
I1212 11:51:24.317086 3137550 load_balancer.go:480] "detach from network" op="hcops/LoadBalancerOps.detachFromNetwork" loadBalancerID=4 networkID=14
I1212 11:51:24.317223 3137550 load_balancer.go:504] "attach to network" op="hcops/LoadBalancerOps.attachToNetwork" loadBalancerID=4 networkID=15
I1212 11:51:24.317766 3137550 load_balancer.go:504] "attach to network" op="hcops/LoadBalancerOps.attachToNetwork" loadBalancerID=5 networkID=15
I1212 11:51:24.317899 3137550 load_balancer.go:521] "retry due to conflict or lock" op="hcops/LoadBalancerOps.attachToNetwork" delay="1s" err=" (conflict)"
I1212 11:51:25.318268 3137550 load_balancer.go:504] "attach to network" op="hcops/LoadBalancerOps.attachToNetwork" loadBalancerID=5 networkID=15
I1212 11:51:25.318354 3137550 load_balancer.go:521] "retry due to conflict or lock" op="hcops/LoadBalancerOps.attachToNetwork" delay="1s" err=" (locked)"
--- FAIL: TestLoadBalancerOps_ReconcileHCLBTargets (0.00s)
    --- FAIL: TestLoadBalancerOps_ReconcileHCLBTargets/add_k8s_nodes_as_hc_Load_Balancer_targets (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1299ac1]

goroutine 127 [running]:
testing.tRunner.func1.2({0x13b2ee0, 0x21aa2a0})
        /usr/local/go/src/testing/testing.go:1632 +0x230
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1635 +0x35e
panic({0x13b2ee0?, 0x21aa2a0?})
        /usr/local/go/src/runtime/panic.go:785 +0x132
github.com/syself/hetzner-cloud-controller-manager/internal/hcops.(*LoadBalancerOps).ReconcileHCLBTargets(0xc0005a6870, {0x1777850, 0x21f48e0}, 0xc0002898c0, 0xc0005a9688, {0xc0005ad0e0, 0x4, 0xc0003d37d0?})
        /home/guettli/syself/hccm2/internal/hcops/load_balancer.go:732 +0x1841
github.com/syself/hetzner-cloud-controller-manager/internal/hcops_test.TestLoadBalancerOps_ReconcileHCLBTargets.func2(0xc000515380, 0xc000442600?)
        /home/guettli/syself/hccm2/internal/hcops/load_balancer_test.go:1177 +0x4f
github.com/syself/hetzner-cloud-controller-manager/internal/hcops_test.(*LBReconcilementTestCase).run(0xc000442600, 0xc000515380)
        /home/guettli/syself/hccm2/internal/hcops/load_balancer_test.go:627 +0x239
testing.tRunner(0xc000515380, 0xc00005c6d0)
        /usr/local/go/src/testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 126
        /usr/local/go/src/testing/testing.go:1743 +0x390
FAIL    github.com/syself/hetzner-cloud-controller-manager/internal/hcops       2.019s
open ../../hack/.token-dev: no such file or directory
FAIL    github.com/syself/hetzner-cloud-controller-manager/tests/e2e    0.011s
FAIL
```