### PR TITLE
:seedling: fix nil pointer in robot client.

### DIFF
--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -48,6 +48,7 @@ const (
 	hcloudNetworkENVVar  = "HCLOUD_NETWORK"
 	hcloudDebugENVVar    = "HCLOUD_DEBUG"
 	robotDebugENVVar     = "ROBOT_DEBUG"
+	robotEndpointENVVar  = "ROBOT_ENDPOINT"
 
 	// Only as reference - is used in hcops package.
 	// Default is 5 minutes.
@@ -160,8 +161,11 @@ func newCloud(_ io.Reader) (cloudprovider.Interface, error) {
 				roundTripper: http.DefaultTransport,
 			},
 		}
+	} else {
+		httpClient = http.DefaultClient
 	}
-	robotClient, err := cache.NewCachedRobotClient(rootDir, httpClient, "")
+
+	robotClient, err := cache.NewCachedRobotClient(rootDir, httpClient, os.Getenv(robotEndpointENVVar))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -41,6 +41,10 @@ type cacheRobotClient struct {
 // the credentials are optional.
 func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL string) (robotclient.Client, error) {
 	const op = "hcloud/newRobotClient"
+
+	if httpClient == nil {
+		return nil, fmt.Errorf("%s: httpClient is nil", op)
+	}
 	cacheTimeout, err := util.GetEnvDuration(cacheTimeoutENVVar)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", op, err)


### PR DESCRIPTION
There was a nil pointer error.

The httpClient for robot was nil.

The PR includes a test, so that would be catched in a test the next time.

```
goroutine 326 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1feb840, 0x39e6720})
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000826d10?})
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x1feb840?, 0x39e6720?})
    /usr/local/go/src/runtime/panic.go:785 +0x132
net/http.(*Client).do(0x0, 0xc000449180)
    /usr/local/go/src/net/http/client.go:606 +0x1ee
net/http.(*Client).Do(...)
    /usr/local/go/src/net/http/client.go:590
github.com/syself/hrobot-go.(*Client).doRequest(0xc000582a50, 0xc000449180)
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/client.go:125 +0x15f
github.com/syself/hrobot-go.(*Client).doGetRequest(0xc000582a50, {0xc00059bf20?, 0x1?})
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/client.go:85 +0x5a
github.com/syself/hrobot-go.(*Client).ServerGetList(0xc000582a50)
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/server.go:13 +0x58
github.com/syself/hetzner-cloud-controller-manager/internal/robot/client/cache.(*cacheRobotClient).ServerGetList(0xc000582aa0)
    /src/hetzner-cloud-controller-manager/internal/robot/client/cache/client.go:114 +0x53
github.com/syself/hetzner-cloud-controller-manager/internal/hcops.(*LoadBalancerOps).ReconcileHCLBTargets(0xc00098d440, {0x270a390, 0xc000730320}, 0xc00028a240, 0xc0006ff908, {0xc0003afd30, 0x2, 0x0?})
    /src/hetzner-cloud-controller-manager/internal/hcops/load_balancer.go:647 +0x7b4
github.com/syself/hetzner-cloud-controller-manager/hcloud.(*loadBalancers).EnsureLoadBalancer(0xc000b16030, {0x270a390, 0xc000730320}, {0x237f5f4, 0xa}, 0xc0006ff908, {0xc0003afbe0, 0x2, 0x2})
    /src/hetzner-cloud-controller-manager/hcloud/load_balancers.go:181 +0x849
k8s.io/cloud-provider/controllers/service.(*Controller).ensureLoadBalancer(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908)
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:449 +0x1bb
k8s.io/cloud-provider/controllers/service.(*Controller).syncLoadBalancerIfNeeded(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:405 +0x752
k8s.io/cloud-provider/controllers/service.(*Controller).processServiceCreateOrUpdate(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:336 +0x13f
k8s.io/cloud-provider/controllers/service.(*Controller).syncService(0xc00022cdd0, {0x270a390, 0xc000730320}, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:907 +0x286
k8s.io/cloud-provider/controllers/service.(*Controller).processNextServiceItem(0xc00022cdd0, {0x270a390, 0xc000730320})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:287 +0x105
k8s.io/cloud-provider/controllers/service.(*Controller).serviceWorker(...)
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:254
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:259 +0x1f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000af5f70, {0x26e3860, 0xc00098f590}, 0x1, 0xc000697ab0)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000509770, 0x3b9aca00, 0x0, 0x1, 0xc000697ab0)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x270a390, 0xc000730320}, 0xc000a9bf50, 0x3b9aca00, 0x0, 0x1)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:259 +0x87
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:170
created by k8s.io/cloud-provider/controllers/service.(*Controller).Run in goroutine 292
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:241 +0x3b4
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x702bce]

goroutine 326 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000826d10?})
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/runtime/runtime.go:56 +0xcd
panic({0x1feb840?, 0x39e6720?})
    /usr/local/go/src/runtime/panic.go:785 +0x132
net/http.(*Client).do(0x0, 0xc000449180)
    /usr/local/go/src/net/http/client.go:606 +0x1ee
net/http.(*Client).Do(...)
    /usr/local/go/src/net/http/client.go:590
github.com/syself/hrobot-go.(*Client).doRequest(0xc000582a50, 0xc000449180)
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/client.go:125 +0x15f
github.com/syself/hrobot-go.(*Client).doGetRequest(0xc000582a50, {0xc00059bf20?, 0x1?})
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/client.go:85 +0x5a
github.com/syself/hrobot-go.(*Client).ServerGetList(0xc000582a50)
    /go/pkg/mod/github.com/syself/hrobot-go@v0.2.6-beta.1/server.go:13 +0x58
github.com/syself/hetzner-cloud-controller-manager/internal/robot/client/cache.(*cacheRobotClient).ServerGetList(0xc000582aa0)
    /src/hetzner-cloud-controller-manager/internal/robot/client/cache/client.go:114 +0x53
github.com/syself/hetzner-cloud-controller-manager/internal/hcops.(*LoadBalancerOps).ReconcileHCLBTargets(0xc00098d440, {0x270a390, 0xc000730320}, 0xc00028a240, 0xc0006ff908, {0xc0003afd30, 0x2, 0x0?})
    /src/hetzner-cloud-controller-manager/internal/hcops/load_balancer.go:647 +0x7b4
github.com/syself/hetzner-cloud-controller-manager/hcloud.(*loadBalancers).EnsureLoadBalancer(0xc000b16030, {0x270a390, 0xc000730320}, {0x237f5f4, 0xa}, 0xc0006ff908, {0xc0003afbe0, 0x2, 0x2})
    /src/hetzner-cloud-controller-manager/hcloud/load_balancers.go:181 +0x849
k8s.io/cloud-provider/controllers/service.(*Controller).ensureLoadBalancer(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908)
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:449 +0x1bb
k8s.io/cloud-provider/controllers/service.(*Controller).syncLoadBalancerIfNeeded(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:405 +0x752
k8s.io/cloud-provider/controllers/service.(*Controller).processServiceCreateOrUpdate(0xc00022cdd0, {0x270a390, 0xc000730320}, 0xc0006ff908, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:336 +0x13f
k8s.io/cloud-provider/controllers/service.(*Controller).syncService(0xc00022cdd0, {0x270a390, 0xc000730320}, {0xc00005b740, 0x15})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:907 +0x286
k8s.io/cloud-provider/controllers/service.(*Controller).processNextServiceItem(0xc00022cdd0, {0x270a390, 0xc000730320})
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:287 +0x105
k8s.io/cloud-provider/controllers/service.(*Controller).serviceWorker(...)
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:254
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:259 +0x1f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000af5f70, {0x26e3860, 0xc00098f590}, 0x1, 0xc000697ab0)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000509770, 0x3b9aca00, 0x0, 0x1, 0xc000697ab0)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x270a390, 0xc000730320}, 0xc000a9bf50, 0x3b9aca00, 0x0, 0x1)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:259 +0x87
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(...)
    /go/pkg/mod/k8s.io/apimachinery@v0.30.3/pkg/util/wait/backoff.go:170
created by k8s.io/cloud-provider/controllers/service.(*Controller).Run in goroutine 292
    /go/pkg/mod/k8s.io/cloud-provider@v0.30.3/controllers/service/controller.go:241 +0x3b4
stream closed EOF for kube-system/ccm-667bfd894b-cfwt8 (ccm)

```

