### PR TITLE
:seedling: Return err in InstanceExists() when bm-server name is not in cache.

### DIFF
--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -94,6 +94,7 @@ func TestInstances_InstanceExists(t *testing.T) {
 		name     string
 		node     *corev1.Node
 		expected bool
+		wantErr  bool
 	}{
 		{
 			name: "existing server by id",
@@ -156,13 +157,19 @@ func TestInstances_InstanceExists(t *testing.T) {
 					Name: "bm-barfoo",
 				},
 			},
-			expected: false,
+			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			exists, err := instances.InstanceExists(context.TODO(), test.node)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got nil")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -73,11 +73,11 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 
 	for i, s := range serverList {
 		if s.Name == node.Name {
-			server = &serverList[i]
+			return &serverList[i], nil
 		}
 	}
 
-	return server, nil
+	return nil, fmt.Errorf("%s: %w", op, models.Error{Code: models.ErrorCodeServerNotFound, Message: "server not found"})
 }
 
 func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *models.Server, e error) {

--- a/hcloud/util_test.go
+++ b/hcloud/util_test.go
@@ -17,8 +17,41 @@ limitations under the License.
 package hcloud
 
 import (
+	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/syself/hrobot-go/models"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestGetRobotServerByNameReturnsNotFound(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	env.Mux.HandleFunc("/robot/server", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode([]models.ServerResponse{
+			{
+				Server: models.Server{
+					ServerNumber: 321,
+					Name:         "bm-server1",
+				},
+			},
+		})
+	})
+
+	server, err := getRobotServerByName(env.RobotClient, &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-server2"},
+	})
+	require.Nil(t, server)
+	require.Error(t, err)
+	var apiErr models.Error
+	require.True(t, errors.As(err, &apiErr))
+	require.Equal(t, models.ErrorCodeServerNotFound, apiErr.Code)
+}
 
 func Test_stringToLabelValue(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# This is for testing. Not a real feature we want in production!