### PR TITLE
:seedling: Force Cache Refresh when Server was not found by name.

### DIFF
--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/syself/hetzner-cloud-controller-manager/internal/annotation"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/credentials"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/hcops"
+	robotclient "github.com/syself/hetzner-cloud-controller-manager/internal/robot/client"
 	hrobot "github.com/syself/hrobot-go"
 	"github.com/syself/hrobot-go/models"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +45,15 @@ type testEnv struct {
 	Server      *httptest.Server
 	Mux         *http.ServeMux
 	Client      *hcloud.Client
-	RobotClient hrobot.RobotClient
+	RobotClient robotclient.Client
+}
+
+type testRobotClient struct {
+	hrobot.RobotClient
+}
+
+func (c testRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+	return c.ServerGetList()
 }
 
 func (env *testEnv) Teardown() {
@@ -70,7 +79,7 @@ func newTestEnv() testEnv {
 		Server:      server,
 		Mux:         mux,
 		Client:      client,
-		RobotClient: robotClient,
+		RobotClient: testRobotClient{RobotClient: robotClient},
 	}
 }
 

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/syself/hetzner-cloud-controller-manager/internal/annotation"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/credentials"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/hcops"
+	robotclient "github.com/syself/hetzner-cloud-controller-manager/internal/robot/client"
 	hrobot "github.com/syself/hrobot-go"
 	"github.com/syself/hrobot-go/models"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +45,7 @@ type testEnv struct {
 	Server      *httptest.Server
 	Mux         *http.ServeMux
 	Client      *hcloud.Client
-	RobotClient hrobot.RobotClient
+	RobotClient robotclient.Client
 }
 
 func (env *testEnv) Teardown() {
@@ -70,7 +71,7 @@ func newTestEnv() testEnv {
 		Server:      server,
 		Mux:         mux,
 		Client:      client,
-		RobotClient: robotClient,
+		RobotClient: robotclient.New(robotClient),
 	}
 }
 

--- a/hcloud/cloud_test.go
+++ b/hcloud/cloud_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/syself/hetzner-cloud-controller-manager/internal/annotation"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/credentials"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/hcops"
-	robotclient "github.com/syself/hetzner-cloud-controller-manager/internal/robot/client"
 	hrobot "github.com/syself/hrobot-go"
 	"github.com/syself/hrobot-go/models"
 	corev1 "k8s.io/api/core/v1"
@@ -45,15 +44,7 @@ type testEnv struct {
 	Server      *httptest.Server
 	Mux         *http.ServeMux
 	Client      *hcloud.Client
-	RobotClient robotclient.Client
-}
-
-type testRobotClient struct {
-	hrobot.RobotClient
-}
-
-func (c testRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
-	return c.ServerGetList()
+	RobotClient hrobot.RobotClient
 }
 
 func (env *testEnv) Teardown() {
@@ -79,7 +70,7 @@ func newTestEnv() testEnv {
 		Server:      server,
 		Mux:         mux,
 		Client:      client,
-		RobotClient: testRobotClient{RobotClient: robotClient},
+		RobotClient: robotClient,
 	}
 }
 

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -49,12 +49,7 @@ type instances struct {
 var errServerNotFound = fmt.Errorf("server not found")
 
 func newInstances(client *hcloud.Client, robotClient robotclient.Client, addressFamily addressFamily, networkID int64) *instances {
-	return &instances{
-		client:        client,
-		robotClient:   robotClient,
-		addressFamily: addressFamily,
-		networkID:     networkID,
-	}
+	return &instances{client, robotClient, addressFamily, networkID}
 }
 
 // lookupServer attempts to locate the corresponding hcloud.Server or models.Server (robot server) for a given v1.Node.

--- a/hcloud/instances.go
+++ b/hcloud/instances.go
@@ -49,7 +49,12 @@ type instances struct {
 var errServerNotFound = fmt.Errorf("server not found")
 
 func newInstances(client *hcloud.Client, robotClient robotclient.Client, addressFamily addressFamily, networkID int64) *instances {
-	return &instances{client, robotClient, addressFamily, networkID}
+	return &instances{
+		client:        client,
+		robotClient:   robotClient,
+		addressFamily: addressFamily,
+		networkID:     networkID,
+	}
 }
 
 // lookupServer attempts to locate the corresponding hcloud.Server or models.Server (robot server) for a given v1.Node.

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+	"github.com/syself/hetzner-cloud-controller-manager/internal/robot/client/cache"
 	"github.com/syself/hrobot-go/models"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,6 +171,69 @@ func TestInstances_InstanceExists(t *testing.T) {
 				t.Fatalf("Expected server to exist %v but got %v", test.expected, exists)
 			}
 		})
+	}
+}
+
+func TestInstances_InstanceExistsRobotServerCreatedAfterCacheFill(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	resetEnv := Setenv(t,
+		"ROBOT_USER_NAME", "user",
+		"ROBOT_PASSWORD", "pass",
+		"CACHE_TIMEOUT", "1h",
+	)
+	defer resetEnv()
+
+	// servers backs the Robot list response and is mutated during the test.
+	servers := make([]models.Server, 0, 2)
+	servers = append(servers, models.Server{
+		ServerIP:      "123.123.123.123",
+		ServerIPv6Net: "2a01:f48:111:4221::",
+		ServerNumber:  321,
+		Name:          "bm-existing",
+	})
+	env.Mux.HandleFunc("/robot/server", func(w http.ResponseWriter, _ *http.Request) {
+		responses := make([]models.ServerResponse, 0, len(servers))
+		for _, server := range servers {
+			responses = append(responses, models.ServerResponse{Server: server})
+		}
+		json.NewEncoder(w).Encode(responses)
+	})
+
+	robotClient, err := cache.NewCachedRobotClient(t.TempDir(), env.Server.Client(), env.Server.URL+"/robot")
+	if err != nil {
+		t.Fatalf("Unexpected error creating cached robot client: %v", err)
+	}
+
+	instances := newInstances(env.Client, robotClient, AddressFamilyIPv4, 0)
+
+	// Warm the cache while bm-new does not exist yet.
+	exists, err := instances.InstanceExists(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-existing"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error warming cache: %v", err)
+	}
+	if !exists {
+		t.Fatal("Expected bm-existing to exist")
+	}
+
+	servers = append(servers, models.Server{
+		ServerIP:      "123.123.123.124",
+		ServerIPv6Net: "2a01:f48:111:4222::",
+		ServerNumber:  322,
+		Name:          "bm-new",
+	})
+
+	exists, err = instances.InstanceExists(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-new"},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error for bm-new: %v", err)
+	}
+	if !exists {
+		t.Fatal("Expected bm-new to exist after it was created")
 	}
 }
 

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -237,6 +237,65 @@ func TestInstances_InstanceExistsRobotServerCreatedAfterCacheFill(t *testing.T) 
 	}
 }
 
+func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	resetEnv := Setenv(t,
+		"ROBOT_USER_NAME", "user",
+		"ROBOT_PASSWORD", "pass",
+		"CACHE_TIMEOUT", "1h",
+	)
+	defer resetEnv()
+
+	robotServerListCalls := 0
+	env.Mux.HandleFunc("/robot/server", func(w http.ResponseWriter, _ *http.Request) {
+		robotServerListCalls++
+		json.NewEncoder(w).Encode([]models.ServerResponse{
+			{
+				Server: models.Server{
+					ServerIP:      "123.123.123.123",
+					ServerIPv6Net: "2a01:f48:111:4221::",
+					ServerNumber:  321,
+					Name:          "bm-existing",
+				},
+			},
+		})
+	})
+
+	robotClient, err := cache.NewCachedRobotClient(t.TempDir(), env.Server.Client(), env.Server.URL+"/robot")
+	if err != nil {
+		t.Fatalf("Unexpected error creating cached robot client: %v", err)
+	}
+
+	instances := newInstances(env.Client, robotClient, AddressFamilyIPv4, 0)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "bm-missing"},
+	}
+
+	exists, err := instances.InstanceExists(context.TODO(), node)
+	if err != nil {
+		t.Fatalf("Unexpected error on first miss: %v", err)
+	}
+	if exists {
+		t.Fatal("Expected bm-missing to be absent on first lookup")
+	}
+	if robotServerListCalls != 2 {
+		t.Fatalf("Expected 2 Robot list calls after first miss, got %d", robotServerListCalls)
+	}
+
+	exists, err = instances.InstanceExists(context.TODO(), node)
+	if err != nil {
+		t.Fatalf("Unexpected error on second miss: %v", err)
+	}
+	if exists {
+		t.Fatal("Expected bm-missing to be absent on second lookup")
+	}
+	if robotServerListCalls != 2 {
+		t.Fatalf("Expected repeated miss to skip force refresh, got %d Robot list calls", robotServerListCalls)
+	}
+}
+
 func TestInstances_InstanceShutdown(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -237,10 +237,17 @@ func TestInstances_InstanceExistsRobotServerCreatedAfterCacheFill(t *testing.T) 
 	}
 }
 
-func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh(t *testing.T) {
-	// If a node name is not in the cache, then only on the time the cache should be refreshed. A
-	// second time (during the time of CACHE_TIMEOUT), the unknown node name should not trigger a
-	// cache refresh again.
+func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsSecondForceRefresh(t *testing.T) {
+	// This test exercises the name-based Robot lookup path in getRobotServerByName:
+	//
+	// 1. ServerGetList() checks the cached Robot server list.
+	// 2. If the name is missing there, ServerGetListForceRefresh(node.Name) does one uncached reload.
+	// 3. A second lookup for the same still-missing name within CACHE_TIMEOUT must not trigger
+	//    another uncached reload.
+	//
+	// The behavior is important because CAPH can rename Robot servers during provisioning, so the
+	// first miss should recover from a stale cache, but repeated misses for the same name should not
+	// hammer the Robot API.
 	env := newTestEnv()
 	defer env.Teardown()
 
@@ -251,9 +258,9 @@ func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh
 	)
 	defer resetEnv()
 
-	robotServerListCalls := 0
+	robotListHTTPCalls := 0
 	env.Mux.HandleFunc("/robot/server", func(w http.ResponseWriter, _ *http.Request) {
-		robotServerListCalls++
+		robotListHTTPCalls++
 		json.NewEncoder(w).Encode([]models.ServerResponse{
 			{
 				Server: models.Server{
@@ -276,6 +283,9 @@ func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh
 		ObjectMeta: metav1.ObjectMeta{Name: "bm-missing"},
 	}
 
+	// First lookup for bm-missing:
+	// - ServerGetList() loads the current list from Robot. That is HTTP call 1.
+	// - bm-missing is not present, so getRobotServerByName forces one reload. That is HTTP call 2.
 	exists, err := instances.InstanceExists(context.TODO(), node)
 	if err != nil {
 		t.Fatalf("Unexpected error on first miss: %v", err)
@@ -283,10 +293,16 @@ func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh
 	if exists {
 		t.Fatal("Expected bm-missing to be absent on first lookup")
 	}
-	if robotServerListCalls != 2 {
-		t.Fatalf("Expected 2 Robot list calls after first miss, got %d", robotServerListCalls)
+	if robotListHTTPCalls != 2 {
+		t.Fatalf("Expected 2 Robot list calls after first miss, got %d", robotListHTTPCalls)
 	}
+	callsAfterFirstMiss := robotListHTTPCalls
 
+	// Second lookup for the same missing name within CACHE_TIMEOUT:
+	// - ServerGetList() is served from cache, so there is no extra HTTP call.
+	// - ServerGetListForceRefresh(node.Name) notices that bm-missing already triggered a forced
+	//   refresh in this cache window, so it reuses the cached list instead of issuing another HTTP
+	//   request.
 	exists, err = instances.InstanceExists(context.TODO(), node)
 	if err != nil {
 		t.Fatalf("Unexpected error on second miss: %v", err)
@@ -294,8 +310,8 @@ func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh
 	if exists {
 		t.Fatal("Expected bm-missing to be absent on second lookup")
 	}
-	if robotServerListCalls != 2 {
-		t.Fatalf("Expected repeated miss to skip force refresh, got %d Robot list calls", robotServerListCalls)
+	if robotListHTTPCalls != callsAfterFirstMiss {
+		t.Fatalf("Expected repeated miss to skip force refresh, got %d Robot list calls", robotListHTTPCalls)
 	}
 }
 

--- a/hcloud/instances_test.go
+++ b/hcloud/instances_test.go
@@ -238,6 +238,9 @@ func TestInstances_InstanceExistsRobotServerCreatedAfterCacheFill(t *testing.T) 
 }
 
 func TestInstances_InstanceExistsRobotServerRepeatedMissingNameSkipsForceRefresh(t *testing.T) {
+	// If a node name is not in the cache, then only on the time the cache should be refreshed. A
+	// second time (during the time of CACHE_TIMEOUT), the unknown node name should not trigger a
+	// cache refresh again.
 	env := newTestEnv()
 	defer env.Teardown()
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -79,21 +79,13 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 
 	// CAPH changes the Robot server name during provisioning. This means the cache of the
 	// server-name-to-server-ID mapping could be outdated. Force one uncached Robot list reload for
-	// that name to bridge the rename, then suppress repeated forced refreshes for the same missing
-	// name until the normal Robot list cache timeout has elapsed.
-	if c.NodeHasAlreadyForcedRefresh(string(node.Name)) {
-		// This node name already triggered a force refresh. Don't refresh again.
-		return nil, nil
-	}
-
-	serverList, err = c.ServerGetListForceRefresh()
+	// that name to handle the rename. The Robot client suppresses repeated forced refreshes for the
+	// same missing name until the normal Robot list cache timeout has elapsed.
+	serverList, err = c.ServerGetListForceRefresh(string(node.Name))
 	if err != nil {
 		hcops.HandleRateLimitExceededError(err, node)
 		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)
 	}
-
-	// Remember this node name, so that it does not trigger a cache refresh again.
-	c.NodeTriggeredForcedRefresh(string(node.Name))
 
 	for i, s := range serverList {
 		if s.Name == node.Name {

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -86,6 +86,7 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 	// Only the cached Robot client can bypass its timeout and reload immediately.
 	forceRefreshClient, ok := c.(robotServerListForceRefreshClient)
 	if !ok {
+		// robot Client does not support force refresh
 		return nil, nil
 	}
 
@@ -97,10 +98,12 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 
 	for i, s := range serverList {
 		if s.Name == node.Name {
+			// Server was found after cache refresh
 			return &serverList[i], nil
 		}
 	}
 
+	// No server found.
 	return nil, nil
 }
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -37,12 +37,12 @@ type robotServerListForceRefreshClient interface {
 	// bypassing the normal cache timeout.
 	ServerGetListForceRefresh() ([]models.Server, error)
 
-	// HasMissingServerName reports whether name was already missing in the
-	// current cache generation.
+	// HasMissingServerName reports whether name is still cached as a recent miss
+	// and should skip another forced refresh for now.
 	HasMissingServerName(name string) bool
 
-	// RememberMissingServerName records name as missing until the cache is
-	// refreshed again.
+	// RememberMissingServerName records name as missing until its miss-cache
+	// entry expires.
 	RememberMissingServerName(name string)
 }
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -30,22 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// robotServerListForceRefreshClient is implemented by Robot clients that can
-// bypass their cache timeout and remember names missing in the current cache.
-type robotServerListForceRefreshClient interface {
-	// ServerGetListForceRefresh reloads the Robot server list immediately,
-	// bypassing the normal cache timeout.
-	ServerGetListForceRefresh() ([]models.Server, error)
-
-	// HasMissingServerName reports whether name is still cached as a recent miss
-	// and should skip another forced refresh for now.
-	HasMissingServerName(name string) bool
-
-	// RememberMissingServerName records name as missing until its miss-cache
-	// entry expires.
-	RememberMissingServerName(name string)
-}
-
 func getHCloudServerByName(ctx context.Context, c *hcloud.Client, name string) (*hcloud.Server, error) {
 	const op = "hcloud/getServerByName"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
@@ -93,19 +77,19 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		}
 	}
 
-	// Only the cached Robot client can bypass its timeout and reload immediately.
-	forceRefreshClient, ok := c.(robotServerListForceRefreshClient)
-	if !ok {
-		// robot Client does not support force refresh
+	// CAPH can create the bare-metal server first and only update the Kubernetes
+	// Node name afterwards. During that short window the Robot list cache can
+	// still hold the old server name, so a name lookup would incorrectly conclude
+	// that the server disappeared and the node could be deleted immediately.
+	// Force one uncached Robot list reload for that name to bridge the rename,
+	// then suppress repeated forced refreshes for the same missing name until the
+	// normal Robot list cache timeout has elapsed.
+	if c.NodeHasAlreadyForcedRefresh(string(node.Name)) {
+		// This node name already triggered a force refresh. Don't refresh again.
 		return nil, nil
 	}
 
-	if forceRefreshClient.HasMissingServerName(string(node.Name)) {
-		// This node name already triggerd a force refresh. Don't refresh again.
-		return nil, nil
-	}
-
-	serverList, err = forceRefreshClient.ServerGetListForceRefresh()
+	serverList, err = c.ServerGetListForceRefresh()
 	if err != nil {
 		hcops.HandleRateLimitExceededError(err, node)
 		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)
@@ -119,7 +103,7 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 	}
 
 	// Remember this node name, so that it does not trigger a cache refresh again.
-	forceRefreshClient.RememberMissingServerName(string(node.Name))
+	c.NodeTriggeredForcedRefresh(string(node.Name))
 
 	// No server found.
 	return nil, nil

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -77,13 +77,10 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		}
 	}
 
-	// CAPH can create the bare-metal server first and only update the Kubernetes
-	// Node name afterwards. During that short window the Robot list cache can
-	// still hold the old server name, so a name lookup would incorrectly conclude
-	// that the server disappeared and the node could be deleted immediately.
-	// Force one uncached Robot list reload for that name to bridge the rename,
-	// then suppress repeated forced refreshes for the same missing name until the
-	// normal Robot list cache timeout has elapsed.
+	// CAPH changes the Robot server name during provisioning. This means the cache of the
+	// server-name-to-server-ID mapping could be outdated. Force one uncached Robot list reload for
+	// that name to bridge the rename, then suppress repeated forced refreshes for the same missing
+	// name until the normal Robot list cache timeout has elapsed.
 	if c.NodeHasAlreadyForcedRefresh(string(node.Name)) {
 		// This node name already triggered a force refresh. Don't refresh again.
 		return nil, nil

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -31,9 +31,11 @@ import (
 )
 
 // robotServerListForceRefreshClient is implemented by Robot clients that can
-// bypass their cache timeout and reload the server list immediately.
+// bypass their cache timeout and remember names missing in the current cache.
 type robotServerListForceRefreshClient interface {
 	ServerGetListForceRefresh() ([]models.Server, error)
+	HasMissingServerName(name string) bool
+	RememberMissingServerName(name string)
 }
 
 func getHCloudServerByName(ctx context.Context, c *hcloud.Client, name string) (*hcloud.Server, error) {
@@ -89,6 +91,9 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		// robot Client does not support force refresh
 		return nil, nil
 	}
+	if forceRefreshClient.HasMissingServerName(string(node.Name)) {
+		return nil, nil
+	}
 
 	serverList, err = forceRefreshClient.ServerGetListForceRefresh()
 	if err != nil {
@@ -104,6 +109,7 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 	}
 
 	// No server found.
+	forceRefreshClient.RememberMissingServerName(string(node.Name))
 	return nil, nil
 }
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -95,15 +95,15 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)
 	}
 
+	// Remember this node name, so that it does not trigger a cache refresh again.
+	c.NodeTriggeredForcedRefresh(string(node.Name))
+
 	for i, s := range serverList {
 		if s.Name == node.Name {
 			// Server was found after cache refresh
 			return &serverList[i], nil
 		}
 	}
-
-	// Remember this node name, so that it does not trigger a cache refresh again.
-	c.NodeTriggeredForcedRefresh(string(node.Name))
 
 	// No server found.
 	return nil, nil

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -71,13 +71,18 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
-	for i, s := range serverList {
-		if s.Name == node.Name {
-			server = &serverList[i]
-		}
+	server = findRobotServerByName(serverList, string(node.Name))
+	if server != nil {
+		return server, nil
 	}
 
-	return server, nil
+	serverList, err = c.ServerGetListForceRefresh()
+	if err != nil {
+		hcops.HandleRateLimitExceededError(err, node)
+		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)
+	}
+
+	return findRobotServerByName(serverList, string(node.Name)), nil
 }
 
 func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *models.Server, e error) {
@@ -114,6 +119,15 @@ func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *mod
 
 	// return nil, nil if server could not be found
 	return server, nil
+}
+
+func findRobotServerByName(serverList []models.Server, name string) *models.Server {
+	for i, s := range serverList {
+		if s.Name == name {
+			return &serverList[i]
+		}
+	}
+	return nil
 }
 
 func isHCloudServerByName(name string) bool {

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -33,8 +33,16 @@ import (
 // robotServerListForceRefreshClient is implemented by Robot clients that can
 // bypass their cache timeout and remember names missing in the current cache.
 type robotServerListForceRefreshClient interface {
+	// ServerGetListForceRefresh reloads the Robot server list immediately,
+	// bypassing the normal cache timeout.
 	ServerGetListForceRefresh() ([]models.Server, error)
+
+	// HasMissingServerName reports whether name was already missing in the
+	// current cache generation.
 	HasMissingServerName(name string) bool
+
+	// RememberMissingServerName records name as missing until the cache is
+	// refreshed again.
 	RememberMissingServerName(name string)
 }
 
@@ -91,7 +99,9 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		// robot Client does not support force refresh
 		return nil, nil
 	}
+
 	if forceRefreshClient.HasMissingServerName(string(node.Name)) {
+		// This node name already triggerd a force refresh. Don't refresh again.
 		return nil, nil
 	}
 
@@ -108,8 +118,10 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		}
 	}
 
-	// No server found.
+	// Remember this node name, so that it does not trigger a cache refresh again.
 	forceRefreshClient.RememberMissingServerName(string(node.Name))
+
+	// No server found.
 	return nil, nil
 }
 

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -30,6 +30,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type robotServerListForceRefreshClient interface {
+	ServerGetListForceRefresh() ([]models.Server, error)
+}
+
 func getHCloudServerByName(ctx context.Context, c *hcloud.Client, name string) (*hcloud.Server, error) {
 	const op = "hcloud/getServerByName"
 	metrics.OperationCalled.WithLabelValues(op).Inc()
@@ -77,7 +81,12 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		}
 	}
 
-	serverList, err = c.ServerGetListForceRefresh()
+	forceRefreshClient, ok := c.(robotServerListForceRefreshClient)
+	if !ok {
+		return nil, nil
+	}
+
+	serverList, err = forceRefreshClient.ServerGetListForceRefresh()
 	if err != nil {
 		hcops.HandleRateLimitExceededError(err, node)
 		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -30,6 +30,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// robotServerListForceRefreshClient is implemented by Robot clients that can
+// bypass their cache timeout and reload the server list immediately.
 type robotServerListForceRefreshClient interface {
 	ServerGetListForceRefresh() ([]models.Server, error)
 }
@@ -81,6 +83,7 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		}
 	}
 
+	// Only the cached Robot client can bypass its timeout and reload immediately.
 	forceRefreshClient, ok := c.(robotServerListForceRefreshClient)
 	if !ok {
 		return nil, nil

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -71,9 +71,10 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
-	server = findRobotServerByName(serverList, string(node.Name))
-	if server != nil {
-		return server, nil
+	for i, s := range serverList {
+		if s.Name == node.Name {
+			return &serverList[i], nil
+		}
 	}
 
 	serverList, err = c.ServerGetListForceRefresh()
@@ -82,7 +83,13 @@ func getRobotServerByName(c robotclient.Client, node *corev1.Node) (server *mode
 		return nil, fmt.Errorf("%s: force refresh after cache miss: %w", op, err)
 	}
 
-	return findRobotServerByName(serverList, string(node.Name)), nil
+	for i, s := range serverList {
+		if s.Name == node.Name {
+			return &serverList[i], nil
+		}
+	}
+
+	return nil, nil
 }
 
 func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *models.Server, e error) {
@@ -119,15 +126,6 @@ func getRobotServerByID(c robotclient.Client, id int, node *corev1.Node) (s *mod
 
 	// return nil, nil if server could not be found
 	return server, nil
-}
-
-func findRobotServerByName(serverList []models.Server, name string) *models.Server {
-	for i, s := range serverList {
-		if s.Name == name {
-			return &serverList[i]
-		}
-	}
-	return nil
 }
 
 func isHCloudServerByName(name string) bool {

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -14,10 +14,6 @@ func (m *RobotClient) ServerGetList() ([]models.Server, error) {
 	return getRobotServers(args, 0), args.Error(1)
 }
 
-func (m *RobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
-	return m.ServerGetList()
-}
-
 func (m *RobotClient) SetCredentials(_, _ string) error {
 	args := m.Called()
 	return args.Error(3)

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -19,10 +19,13 @@ func (m *RobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
 }
 
 func (m *RobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+	_ = nodeName
 	return false
 }
 
-func (m *RobotClient) NodeTriggeredForcedRefresh(nodeName string) {}
+func (m *RobotClient) NodeTriggeredForcedRefresh(nodeName string) {
+	_ = nodeName
+}
 
 func (m *RobotClient) SetCredentials(_, _ string) error {
 	args := m.Called()

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -14,6 +14,16 @@ func (m *RobotClient) ServerGetList() ([]models.Server, error) {
 	return getRobotServers(args, 0), args.Error(1)
 }
 
+func (m *RobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+	return m.ServerGetList()
+}
+
+func (m *RobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+	return false
+}
+
+func (m *RobotClient) NodeTriggeredForcedRefresh(nodeName string) {}
+
 func (m *RobotClient) SetCredentials(_, _ string) error {
 	args := m.Called()
 	return args.Error(3)

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -14,6 +14,10 @@ func (m *RobotClient) ServerGetList() ([]models.Server, error) {
 	return getRobotServers(args, 0), args.Error(1)
 }
 
+func (m *RobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+	return m.ServerGetList()
+}
+
 func (m *RobotClient) SetCredentials(_, _ string) error {
 	args := m.Called()
 	return args.Error(3)

--- a/internal/mocks/robot.go
+++ b/internal/mocks/robot.go
@@ -14,17 +14,8 @@ func (m *RobotClient) ServerGetList() ([]models.Server, error) {
 	return getRobotServers(args, 0), args.Error(1)
 }
 
-func (m *RobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+func (m *RobotClient) ServerGetListForceRefresh(_ string) ([]models.Server, error) {
 	return m.ServerGetList()
-}
-
-func (m *RobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
-	_ = nodeName
-	return false
-}
-
-func (m *RobotClient) NodeTriggeredForcedRefresh(nodeName string) {
-	_ = nodeName
 }
 
 func (m *RobotClient) SetCredentials(_, _ string) error {

--- a/internal/robot/client/adapter.go
+++ b/internal/robot/client/adapter.go
@@ -28,9 +28,12 @@ func (a *adapter) ServerGetListForceRefresh() ([]models.Server, error) {
 // NodeHasAlreadyForcedRefresh always reports false for plain Robot clients because
 // they do not track forced-refresh state.
 func (a *adapter) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+	_ = nodeName
 	return false
 }
 
 // NodeTriggeredForcedRefresh is a no-op for plain Robot clients because they do
 // not cache forced-refresh state.
-func (a *adapter) NodeTriggeredForcedRefresh(nodeName string) {}
+func (a *adapter) NodeTriggeredForcedRefresh(nodeName string) {
+	_ = nodeName
+}

--- a/internal/robot/client/adapter.go
+++ b/internal/robot/client/adapter.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	hrobot "github.com/syself/hrobot-go"
+	"github.com/syself/hrobot-go/models"
+)
+
+var _ Client = &adapter{}
+
+type adapter struct {
+	hrobot.RobotClient
+}
+
+// New wraps a plain Robot client so it satisfies the local Client interface.
+func New(robotClient hrobot.RobotClient) Client {
+	if robotClient == nil {
+		return nil
+	}
+	return &adapter{RobotClient: robotClient}
+}
+
+// ServerGetListForceRefresh falls back to the plain list call because the
+// uncached behavior only exists in the cache-backed client implementation.
+func (a *adapter) ServerGetListForceRefresh() ([]models.Server, error) {
+	return a.ServerGetList()
+}
+
+// NodeHasAlreadyForcedRefresh always reports false for plain Robot clients because
+// they do not track forced-refresh state.
+func (a *adapter) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+	return false
+}
+
+// NodeTriggeredForcedRefresh is a no-op for plain Robot clients because they do
+// not cache forced-refresh state.
+func (a *adapter) NodeTriggeredForcedRefresh(nodeName string) {}

--- a/internal/robot/client/adapter.go
+++ b/internal/robot/client/adapter.go
@@ -21,19 +21,6 @@ func New(robotClient hrobot.RobotClient) Client {
 
 // ServerGetListForceRefresh falls back to the plain list call because the
 // uncached behavior only exists in the cache-backed client implementation.
-func (a *adapter) ServerGetListForceRefresh() ([]models.Server, error) {
+func (a *adapter) ServerGetListForceRefresh(_ string) ([]models.Server, error) {
 	return a.ServerGetList()
-}
-
-// NodeHasAlreadyForcedRefresh always reports false for plain Robot clients because
-// they do not track forced-refresh state.
-func (a *adapter) NodeHasAlreadyForcedRefresh(nodeName string) bool {
-	_ = nodeName
-	return false
-}
-
-// NodeTriggeredForcedRefresh is a no-op for plain Robot clients because they do
-// not cache forced-refresh state.
-func (a *adapter) NodeTriggeredForcedRefresh(nodeName string) {
-	_ = nodeName
 }

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -18,6 +18,11 @@ const (
 	robotUserNameENVVar = "ROBOT_USER_NAME"
 	robotPasswordENVVar = "ROBOT_PASSWORD"
 	cacheTimeoutENVVar  = "CACHE_TIMEOUT"
+
+	// We don't want to remember a node name for ever. Imagine a bm machine with constant hostname
+	// gets provisioned twice. Then we want the second time to work like the first: The cache of
+	// Robot servers should be updated via ServerGetListForceRefresh().
+	defaultMissingServerNameTTL = 5 * time.Minute
 )
 
 var _ robotclient.Client = &cacheRobotClient{}
@@ -27,11 +32,12 @@ type cacheRobotClient struct {
 	timeout     time.Duration
 
 	lastUpdate time.Time
+	now        func() time.Time
 
 	// cache
 	l                  []models.Server
 	m                  map[int]*models.Server
-	missingServerNames []string
+	missingServerNames map[string]time.Time
 }
 
 // NewCachedRobotClient creates a new robot client with caching enabled.
@@ -86,6 +92,7 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 	handler := &cacheRobotClient{}
 	handler.timeout = cacheTimeout
 	handler.robotClient = c
+	handler.now = time.Now
 	return handler, nil
 }
 
@@ -106,7 +113,7 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 		}
 
 		// set time of last update
-		c.lastUpdate = time.Now()
+		c.lastUpdate = c.currentTime()
 		c.missingServerNames = nil
 	}
 
@@ -136,7 +143,7 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 		}
 
 		// set time of last update
-		c.lastUpdate = time.Now()
+		c.lastUpdate = c.currentTime()
 		c.missingServerNames = nil
 	}
 
@@ -149,27 +156,30 @@ func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) 
 	return c.ServerGetList()
 }
 
-// HasMissingServerName reports whether name was already missing in the
-// currently cached Robot server list.
+// HasMissingServerName reports whether name is still cached as a recent miss.
 func (c *cacheRobotClient) HasMissingServerName(name string) bool {
-	for _, missingName := range c.missingServerNames {
-		if missingName == name {
-			return true
-		}
+	if c.missingServerNames == nil {
+		return false
 	}
-	return false
+
+	expiresAt, found := c.missingServerNames[name]
+	if !found {
+		return false
+	}
+	if c.currentTime().After(expiresAt) {
+		delete(c.missingServerNames, name)
+		return false
+	}
+	return true
 }
 
-// RememberMissingServerName stores name in the bounded list of cache misses for
-// the current cache generation.
+// RememberMissingServerName stores name in the cache of recent misses until its
+// expiration time is reached.
 func (c *cacheRobotClient) RememberMissingServerName(name string) {
-	if c.HasMissingServerName(name) {
-		return
+	if c.missingServerNames == nil {
+		c.missingServerNames = make(map[string]time.Time)
 	}
-	c.missingServerNames = append(c.missingServerNames, name)
-	if len(c.missingServerNames) > 1000 {
-		c.missingServerNames = c.missingServerNames[len(c.missingServerNames)-1000:]
-	}
+	c.missingServerNames[name] = c.currentTime().Add(defaultMissingServerNameTTL)
 }
 
 func (c *cacheRobotClient) shouldSync() bool {
@@ -178,10 +188,17 @@ func (c *cacheRobotClient) shouldSync() bool {
 		c.m = make(map[int]*models.Server)
 		return true
 	}
-	if time.Now().After(c.lastUpdate.Add(c.timeout)) {
+	if c.currentTime().After(c.lastUpdate.Add(c.timeout)) {
 		return true
 	}
 	return false
+}
+
+func (c *cacheRobotClient) currentTime() time.Time {
+	if c.now == nil {
+		return time.Now()
+	}
+	return c.now()
 }
 
 func (c *cacheRobotClient) SetCredentials(username, password string) error {

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -90,22 +90,9 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 
 func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 	if c.shouldSync() {
-		list, err := c.robotClient.ServerGetList()
-		if err != nil {
+		if _, err := c.sync(); err != nil {
 			return nil, err
 		}
-
-		// populate list
-		c.l = list
-
-		// remove all entries from map and populate it freshly
-		c.m = make(map[int]*models.Server)
-		for i, server := range list {
-			c.m[server.ServerNumber] = &list[i]
-		}
-
-		// set time of last update
-		c.lastUpdate = time.Now()
 	}
 
 	server, found := c.m[id]
@@ -119,25 +106,15 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 
 func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 	if c.shouldSync() {
-		list, err := c.robotClient.ServerGetList()
-		if err != nil {
-			return list, err
-		}
-
-		// populate list
-		c.l = list
-
-		// remove all entries from map and populate it freshly
-		c.m = make(map[int]*models.Server)
-		for i, server := range list {
-			c.m[server.ServerNumber] = &list[i]
-		}
-
-		// set time of last update
-		c.lastUpdate = time.Now()
+		return c.sync()
 	}
 
 	return c.l, nil
+}
+
+// ServerGetListForceRefresh bypasses the timeout check and reloads the cache from Robot.
+func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+	return c.sync()
 }
 
 func (c *cacheRobotClient) shouldSync() bool {
@@ -160,4 +137,25 @@ func (c *cacheRobotClient) SetCredentials(username, password string) error {
 	// The credentials have been updated, so we need to invalidate the cache.
 	c.m = nil
 	return nil
+}
+
+func (c *cacheRobotClient) sync() ([]models.Server, error) {
+	list, err := c.robotClient.ServerGetList()
+	if err != nil {
+		return list, err
+	}
+
+	// populate list
+	c.l = list
+
+	// remove all entries from map and repopulate it from the current list
+	c.m = make(map[int]*models.Server)
+	for i, server := range list {
+		c.m[server.ServerNumber] = &list[i]
+	}
+
+	// set time of last update
+	c.lastUpdate = time.Now()
+
+	return c.l, nil
 }

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -29,8 +29,9 @@ type cacheRobotClient struct {
 	lastUpdate time.Time
 
 	// cache
-	l []models.Server
-	m map[int]*models.Server
+	l                  []models.Server
+	m                  map[int]*models.Server
+	missingServerNames []string
 }
 
 // NewCachedRobotClient creates a new robot client with caching enabled.
@@ -106,6 +107,7 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 
 		// set time of last update
 		c.lastUpdate = time.Now()
+		c.missingServerNames = nil
 	}
 
 	server, found := c.m[id]
@@ -135,6 +137,7 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 
 		// set time of last update
 		c.lastUpdate = time.Now()
+		c.missingServerNames = nil
 	}
 
 	return c.l, nil
@@ -144,6 +147,25 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
 	c.m = nil
 	return c.ServerGetList()
+}
+
+func (c *cacheRobotClient) HasMissingServerName(name string) bool {
+	for _, missingName := range c.missingServerNames {
+		if missingName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *cacheRobotClient) RememberMissingServerName(name string) {
+	if c.HasMissingServerName(name) {
+		return
+	}
+	c.missingServerNames = append(c.missingServerNames, name)
+	if len(c.missingServerNames) > 1000 {
+		c.missingServerNames = c.missingServerNames[len(c.missingServerNames)-1000:]
+	}
 }
 
 func (c *cacheRobotClient) shouldSync() bool {
@@ -165,5 +187,6 @@ func (c *cacheRobotClient) SetCredentials(username, password string) error {
 	}
 	// The credentials have been updated, so we need to invalidate the cache.
 	c.m = nil
+	c.missingServerNames = nil
 	return nil
 }

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -33,10 +33,10 @@ type cacheRobotClient struct {
 	// cache
 	l []models.Server
 	m map[int]*models.Server
-	// forcedRefreshServerNames stores when a node name last triggered a forced
-	// Robot server list refresh. While that timestamp is still within the cache
-	// timeout window, repeated lookups for the same missing name skip the extra
-	// uncached Robot API call.
+
+	// forcedRefreshServerNames stores when a node name last triggered a forced Robot server list
+	// refresh. While that timestamp is still within the cache timeout window, repeated lookups for
+	// the same missing server name skip the extra uncached Robot API call.
 	forcedRefreshServerNames map[string]time.Time
 }
 

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -18,11 +18,7 @@ const (
 	robotUserNameENVVar = "ROBOT_USER_NAME"
 	robotPasswordENVVar = "ROBOT_PASSWORD"
 	cacheTimeoutENVVar  = "CACHE_TIMEOUT"
-
-	// We don't want to remember a node name for ever. Imagine a bm machine with constant hostname
-	// gets provisioned twice. Then we want the second time to work like the first: The cache of
-	// Robot servers should be updated via ServerGetListForceRefresh().
-	defaultMissingServerNameTTL = 5 * time.Minute
+	defaultCacheTimeout = 5 * time.Minute
 )
 
 var _ robotclient.Client = &cacheRobotClient{}
@@ -35,9 +31,13 @@ type cacheRobotClient struct {
 	now        func() time.Time
 
 	// cache
-	l                  []models.Server
-	m                  map[int]*models.Server
-	missingServerNames map[string]time.Time
+	l []models.Server
+	m map[int]*models.Server
+	// forcedRefreshServerNames stores when a node name last triggered a forced
+	// Robot server list refresh. While that timestamp is still within the cache
+	// timeout window, repeated lookups for the same missing name skip the extra
+	// uncached Robot API call.
+	forcedRefreshServerNames map[string]time.Time
 }
 
 // NewCachedRobotClient creates a new robot client with caching enabled.
@@ -58,7 +58,7 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 	}
 
 	if cacheTimeout == 0 {
-		cacheTimeout = 5 * time.Minute
+		cacheTimeout = defaultCacheTimeout
 	}
 
 	credentialsDir := credentials.GetDirectory(rootDir)
@@ -114,7 +114,6 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 
 		// set time of last update
 		c.lastUpdate = c.currentTime()
-		c.missingServerNames = nil
 	}
 
 	server, found := c.m[id]
@@ -144,7 +143,6 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 
 		// set time of last update
 		c.lastUpdate = c.currentTime()
-		c.missingServerNames = nil
 	}
 
 	return c.l, nil
@@ -156,30 +154,31 @@ func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) 
 	return c.ServerGetList()
 }
 
-// HasMissingServerName reports whether name is still cached as a recent miss.
-func (c *cacheRobotClient) HasMissingServerName(name string) bool {
-	if c.missingServerNames == nil {
+// NodeHasAlreadyForcedRefresh reports whether nodeName already triggered a
+// forced refresh within the current cache timeout window.
+func (c *cacheRobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+	if c.forcedRefreshServerNames == nil {
 		return false
 	}
 
-	expiresAt, found := c.missingServerNames[name]
+	forcedAt, found := c.forcedRefreshServerNames[nodeName]
 	if !found {
 		return false
 	}
-	if c.currentTime().After(expiresAt) {
-		delete(c.missingServerNames, name)
+	if c.currentTime().After(forcedAt.Add(c.forceRefreshTimeout())) {
+		delete(c.forcedRefreshServerNames, nodeName)
 		return false
 	}
 	return true
 }
 
-// RememberMissingServerName stores name in the cache of recent misses until its
-// expiration time is reached.
-func (c *cacheRobotClient) RememberMissingServerName(name string) {
-	if c.missingServerNames == nil {
-		c.missingServerNames = make(map[string]time.Time)
+// NodeTriggeredForcedRefresh records that nodeName already triggered a forced
+// refresh.
+func (c *cacheRobotClient) NodeTriggeredForcedRefresh(nodeName string) {
+	if c.forcedRefreshServerNames == nil {
+		c.forcedRefreshServerNames = make(map[string]time.Time)
 	}
-	c.missingServerNames[name] = c.currentTime().Add(defaultMissingServerNameTTL)
+	c.forcedRefreshServerNames[nodeName] = c.currentTime()
 }
 
 func (c *cacheRobotClient) shouldSync() bool {
@@ -201,6 +200,13 @@ func (c *cacheRobotClient) currentTime() time.Time {
 	return c.now()
 }
 
+func (c *cacheRobotClient) forceRefreshTimeout() time.Duration {
+	if c.timeout == 0 {
+		return defaultCacheTimeout
+	}
+	return c.timeout
+}
+
 func (c *cacheRobotClient) SetCredentials(username, password string) error {
 	err := c.robotClient.SetCredentials(username, password)
 	if err != nil {
@@ -208,6 +214,6 @@ func (c *cacheRobotClient) SetCredentials(username, password string) error {
 	}
 	// The credentials have been updated, so we need to invalidate the cache.
 	c.m = nil
-	c.missingServerNames = nil
+	c.forcedRefreshServerNames = nil
 	return nil
 }

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -149,6 +149,8 @@ func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) 
 	return c.ServerGetList()
 }
 
+// HasMissingServerName reports whether name was already missing in the
+// currently cached Robot server list.
 func (c *cacheRobotClient) HasMissingServerName(name string) bool {
 	for _, missingName := range c.missingServerNames {
 		if missingName == name {
@@ -158,6 +160,8 @@ func (c *cacheRobotClient) HasMissingServerName(name string) bool {
 	return false
 }
 
+// RememberMissingServerName stores name in the bounded list of cache misses for
+// the current cache generation.
 func (c *cacheRobotClient) RememberMissingServerName(name string) {
 	if c.HasMissingServerName(name) {
 		return

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -90,9 +90,22 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 
 func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 	if c.shouldSync() {
-		if _, err := c.ServerGetListForceRefresh(); err != nil {
+		list, err := c.robotClient.ServerGetList()
+		if err != nil {
 			return nil, err
 		}
+
+		// populate list
+		c.l = list
+
+		// remove all entries from map and populate it freshly
+		c.m = make(map[int]*models.Server)
+		for i, server := range list {
+			c.m[server.ServerNumber] = &list[i]
+		}
+
+		// set time of last update
+		c.lastUpdate = time.Now()
 	}
 
 	server, found := c.m[id]
@@ -106,32 +119,31 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 
 func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 	if c.shouldSync() {
-		return c.ServerGetListForceRefresh()
+		list, err := c.robotClient.ServerGetList()
+		if err != nil {
+			return list, err
+		}
+
+		// populate list
+		c.l = list
+
+		// remove all entries from map and populate it freshly
+		c.m = make(map[int]*models.Server)
+		for i, server := range list {
+			c.m[server.ServerNumber] = &list[i]
+		}
+
+		// set time of last update
+		c.lastUpdate = time.Now()
 	}
 
 	return c.l, nil
 }
 
-// ServerGetListForceRefresh bypasses the timeout check and reloads the cache from Robot.
+// ServerGetListForceRefresh invalidates the current cache and reloads the list from Robot.
 func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
-	list, err := c.robotClient.ServerGetList()
-	if err != nil {
-		return list, err
-	}
-
-	// populate list
-	c.l = list
-
-	// remove all entries from map and repopulate it from the current list
-	c.m = make(map[int]*models.Server)
-	for i, server := range list {
-		c.m[server.ServerNumber] = &list[i]
-	}
-
-	// set time of last update
-	c.lastUpdate = time.Now()
-
-	return c.l, nil
+	c.m = nil
+	return c.ServerGetList()
 }
 
 func (c *cacheRobotClient) shouldSync() bool {

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -93,6 +93,7 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 	handler.timeout = cacheTimeout
 	handler.robotClient = c
 	handler.now = time.Now
+	handler.forcedRefreshServerNames = make(map[string]time.Time)
 	return handler, nil
 }
 
@@ -156,14 +157,19 @@ func (c *cacheRobotClient) ServerGetListForceRefresh(nodeName string) ([]models.
 		return c.ServerGetList()
 	}
 
+	// setting cache of serverId to serverName mapping to nil, so that the next ServerGetList() will
+	// call the robot API to get the new data.
 	c.m = nil
+
 	list, err := c.ServerGetList()
 	if err != nil {
 		return nil, err
 	}
+
 	if nodeName != "" {
-		c.nodeTriggeredForcedRefresh(nodeName)
+		c.forcedRefreshServerNames[nodeName] = c.currentTime()
 	}
+
 	return list, nil
 }
 
@@ -178,22 +184,14 @@ func (c *cacheRobotClient) nodeHasAlreadyForcedRefresh(nodeName string) bool {
 	if !found {
 		return false
 	}
+
 	if c.currentTime().After(forcedAt.Add(c.forceRefreshTimeout())) {
 		delete(c.forcedRefreshServerNames, nodeName)
 		return false
 	}
+
 	return true
 }
-
-// nodeTriggeredForcedRefresh records that nodeName already triggered a forced
-// refresh.
-func (c *cacheRobotClient) nodeTriggeredForcedRefresh(nodeName string) {
-	if c.forcedRefreshServerNames == nil {
-		c.forcedRefreshServerNames = make(map[string]time.Time)
-	}
-	c.forcedRefreshServerNames[nodeName] = c.currentTime()
-}
-
 func (c *cacheRobotClient) shouldSync() bool {
 	// map is nil means we have no cached value yet
 	if c.m == nil {

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -148,15 +148,28 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 	return c.l, nil
 }
 
-// ServerGetListForceRefresh invalidates the current cache and reloads the list from Robot.
-func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
+// ServerGetListForceRefresh invalidates the current cache and reloads the list
+// from Robot unless nodeName already triggered a forced refresh within the
+// current timeout window.
+func (c *cacheRobotClient) ServerGetListForceRefresh(nodeName string) ([]models.Server, error) {
+	if nodeName != "" && c.nodeHasAlreadyForcedRefresh(nodeName) {
+		return c.ServerGetList()
+	}
+
 	c.m = nil
-	return c.ServerGetList()
+	list, err := c.ServerGetList()
+	if err != nil {
+		return nil, err
+	}
+	if nodeName != "" {
+		c.nodeTriggeredForcedRefresh(nodeName)
+	}
+	return list, nil
 }
 
-// NodeHasAlreadyForcedRefresh reports whether nodeName already triggered a
+// nodeHasAlreadyForcedRefresh reports whether nodeName already triggered a
 // forced refresh within the current cache timeout window.
-func (c *cacheRobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
+func (c *cacheRobotClient) nodeHasAlreadyForcedRefresh(nodeName string) bool {
 	if c.forcedRefreshServerNames == nil {
 		return false
 	}
@@ -172,9 +185,9 @@ func (c *cacheRobotClient) NodeHasAlreadyForcedRefresh(nodeName string) bool {
 	return true
 }
 
-// NodeTriggeredForcedRefresh records that nodeName already triggered a forced
+// nodeTriggeredForcedRefresh records that nodeName already triggered a forced
 // refresh.
-func (c *cacheRobotClient) NodeTriggeredForcedRefresh(nodeName string) {
+func (c *cacheRobotClient) nodeTriggeredForcedRefresh(nodeName string) {
 	if c.forcedRefreshServerNames == nil {
 		c.forcedRefreshServerNames = make(map[string]time.Time)
 	}

--- a/internal/robot/client/cache/client.go
+++ b/internal/robot/client/cache/client.go
@@ -90,7 +90,7 @@ func NewCachedRobotClient(rootDir string, httpClient *http.Client, baseURL strin
 
 func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 	if c.shouldSync() {
-		if _, err := c.sync(); err != nil {
+		if _, err := c.ServerGetListForceRefresh(); err != nil {
 			return nil, err
 		}
 	}
@@ -106,7 +106,7 @@ func (c *cacheRobotClient) ServerGet(id int) (*models.Server, error) {
 
 func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 	if c.shouldSync() {
-		return c.sync()
+		return c.ServerGetListForceRefresh()
 	}
 
 	return c.l, nil
@@ -114,7 +114,24 @@ func (c *cacheRobotClient) ServerGetList() ([]models.Server, error) {
 
 // ServerGetListForceRefresh bypasses the timeout check and reloads the cache from Robot.
 func (c *cacheRobotClient) ServerGetListForceRefresh() ([]models.Server, error) {
-	return c.sync()
+	list, err := c.robotClient.ServerGetList()
+	if err != nil {
+		return list, err
+	}
+
+	// populate list
+	c.l = list
+
+	// remove all entries from map and repopulate it from the current list
+	c.m = make(map[int]*models.Server)
+	for i, server := range list {
+		c.m[server.ServerNumber] = &list[i]
+	}
+
+	// set time of last update
+	c.lastUpdate = time.Now()
+
+	return c.l, nil
 }
 
 func (c *cacheRobotClient) shouldSync() bool {
@@ -137,25 +154,4 @@ func (c *cacheRobotClient) SetCredentials(username, password string) error {
 	// The credentials have been updated, so we need to invalidate the cache.
 	c.m = nil
 	return nil
-}
-
-func (c *cacheRobotClient) sync() ([]models.Server, error) {
-	list, err := c.robotClient.ServerGetList()
-	if err != nil {
-		return list, err
-	}
-
-	// populate list
-	c.l = list
-
-	// remove all entries from map and repopulate it from the current list
-	c.m = make(map[int]*models.Server)
-	for i, server := range list {
-		c.m[server.ServerNumber] = &list[i]
-	}
-
-	// set time of last update
-	c.lastUpdate = time.Now()
-
-	return c.l, nil
 }

--- a/internal/robot/client/cache/client_test.go
+++ b/internal/robot/client/cache/client_test.go
@@ -93,14 +93,14 @@ func TestNodeTriggeredForcedRefreshExpiresAfterCacheTimeout(t *testing.T) {
 		timeout: 10 * time.Minute,
 	}
 
-	client.NodeTriggeredForcedRefresh("bm-missing")
-	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	client.nodeTriggeredForcedRefresh("bm-missing")
+	require.True(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 
 	now = now.Add(client.timeout - time.Second)
-	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.True(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 
 	now = now.Add(2 * time.Second)
-	require.False(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.False(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 	require.Empty(t, client.forcedRefreshServerNames)
 }
 
@@ -111,20 +111,20 @@ func TestNodeTriggeredForcedRefreshRefreshesTimestamp(t *testing.T) {
 		timeout: 5 * time.Minute,
 	}
 
-	client.NodeTriggeredForcedRefresh("bm-missing")
+	client.nodeTriggeredForcedRefresh("bm-missing")
 	firstForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
 	now = now.Add(2 * time.Minute)
-	client.NodeTriggeredForcedRefresh("bm-missing")
+	client.nodeTriggeredForcedRefresh("bm-missing")
 	secondForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
 	require.True(t, secondForcedAt.After(firstForcedAt))
 
 	now = now.Add(4 * time.Minute)
-	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.True(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 
 	now = secondForcedAt.Add(client.timeout + time.Second)
-	require.False(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.False(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 }
 
 func TestServerGetListKeepsForcedRefreshNames(t *testing.T) {
@@ -139,12 +139,12 @@ func TestServerGetListKeepsForcedRefreshNames(t *testing.T) {
 		now:         func() time.Time { return now },
 		timeout:     time.Hour,
 	}
-	client.NodeTriggeredForcedRefresh("bm-missing")
+	client.nodeTriggeredForcedRefresh("bm-missing")
 
 	servers, err := client.ServerGetList()
 	require.NoError(t, err)
 	require.Len(t, servers, 1)
-	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.True(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 	robotClient.AssertExpectations(t)
 }
 

--- a/internal/robot/client/cache/client_test.go
+++ b/internal/robot/client/cache/client_test.go
@@ -85,6 +85,45 @@ func Test_updateRobotCredentials(t *testing.T) {
 	require.Len(t, servers, 1)
 }
 
+func TestRememberMissingServerNameExpires(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
+	client := &cacheRobotClient{
+		now: func() time.Time { return now },
+	}
+
+	client.RememberMissingServerName("bm-missing")
+	require.True(t, client.HasMissingServerName("bm-missing"))
+
+	now = now.Add(defaultMissingServerNameTTL - time.Second)
+	require.True(t, client.HasMissingServerName("bm-missing"))
+
+	now = now.Add(2 * time.Second)
+	require.False(t, client.HasMissingServerName("bm-missing"))
+	require.Empty(t, client.missingServerNames)
+}
+
+func TestRememberMissingServerNameRefreshesExpiry(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
+	client := &cacheRobotClient{
+		now: func() time.Time { return now },
+	}
+
+	client.RememberMissingServerName("bm-missing")
+	firstExpiry := client.missingServerNames["bm-missing"]
+
+	now = now.Add(2 * time.Minute)
+	client.RememberMissingServerName("bm-missing")
+	secondExpiry := client.missingServerNames["bm-missing"]
+
+	require.True(t, secondExpiry.After(firstExpiry))
+
+	now = now.Add(4 * time.Minute)
+	require.True(t, client.HasMissingServerName("bm-missing"))
+
+	now = secondExpiry.Add(time.Second)
+	require.False(t, client.HasMissingServerName("bm-missing"))
+}
+
 func writeCredentials(rootDir, user, password string) error {
 	credentialsDir := credentials.GetDirectory(rootDir)
 	newDir := filepath.Join(credentialsDir, "..dataNew")

--- a/internal/robot/client/cache/client_test.go
+++ b/internal/robot/client/cache/client_test.go
@@ -86,14 +86,14 @@ func Test_updateRobotCredentials(t *testing.T) {
 	require.Len(t, servers, 1)
 }
 
-func TestNodeTriggeredForcedRefreshExpiresAfterCacheTimeout(t *testing.T) {
+func TestForcedRefreshNameExpiresAfterCacheTimeout(t *testing.T) {
 	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
 	client := &cacheRobotClient{
 		now:     func() time.Time { return now },
 		timeout: 10 * time.Minute,
 	}
-
-	client.nodeTriggeredForcedRefresh("bm-missing")
+	client.forcedRefreshServerNames = make(map[string]time.Time)
+	client.forcedRefreshServerNames["bm-missing"] = now
 	require.True(t, client.nodeHasAlreadyForcedRefresh("bm-missing"))
 
 	now = now.Add(client.timeout - time.Second)
@@ -104,18 +104,19 @@ func TestNodeTriggeredForcedRefreshExpiresAfterCacheTimeout(t *testing.T) {
 	require.Empty(t, client.forcedRefreshServerNames)
 }
 
-func TestNodeTriggeredForcedRefreshRefreshesTimestamp(t *testing.T) {
+func TestForcedRefreshNameTimestampCanBeUpdated(t *testing.T) {
 	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
 	client := &cacheRobotClient{
 		now:     func() time.Time { return now },
 		timeout: 5 * time.Minute,
 	}
+	client.forcedRefreshServerNames = make(map[string]time.Time)
 
-	client.nodeTriggeredForcedRefresh("bm-missing")
+	client.forcedRefreshServerNames["bm-missing"] = now
 	firstForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
 	now = now.Add(2 * time.Minute)
-	client.nodeTriggeredForcedRefresh("bm-missing")
+	client.forcedRefreshServerNames["bm-missing"] = now
 	secondForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
 	require.True(t, secondForcedAt.After(firstForcedAt))
@@ -139,8 +140,8 @@ func TestServerGetListKeepsForcedRefreshNames(t *testing.T) {
 		now:         func() time.Time { return now },
 		timeout:     time.Hour,
 	}
-	client.nodeTriggeredForcedRefresh("bm-missing")
-
+	client.forcedRefreshServerNames = make(map[string]time.Time)
+	client.forcedRefreshServerNames["bm-missing"] = now
 	servers, err := client.ServerGetList()
 	require.NoError(t, err)
 	require.Len(t, servers, 1)

--- a/internal/robot/client/cache/client_test.go
+++ b/internal/robot/client/cache/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/syself/hetzner-cloud-controller-manager/internal/credentials"
+	"github.com/syself/hetzner-cloud-controller-manager/internal/mocks"
 	"github.com/syself/hrobot-go/models"
 )
 
@@ -85,43 +86,66 @@ func Test_updateRobotCredentials(t *testing.T) {
 	require.Len(t, servers, 1)
 }
 
-func TestRememberMissingServerNameExpires(t *testing.T) {
+func TestNodeTriggeredForcedRefreshExpiresAfterCacheTimeout(t *testing.T) {
 	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
 	client := &cacheRobotClient{
-		now: func() time.Time { return now },
+		now:     func() time.Time { return now },
+		timeout: 10 * time.Minute,
 	}
 
-	client.RememberMissingServerName("bm-missing")
-	require.True(t, client.HasMissingServerName("bm-missing"))
+	client.NodeTriggeredForcedRefresh("bm-missing")
+	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
 
-	now = now.Add(defaultMissingServerNameTTL - time.Second)
-	require.True(t, client.HasMissingServerName("bm-missing"))
+	now = now.Add(client.timeout - time.Second)
+	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
 
 	now = now.Add(2 * time.Second)
-	require.False(t, client.HasMissingServerName("bm-missing"))
-	require.Empty(t, client.missingServerNames)
+	require.False(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	require.Empty(t, client.forcedRefreshServerNames)
 }
 
-func TestRememberMissingServerNameRefreshesExpiry(t *testing.T) {
+func TestNodeTriggeredForcedRefreshRefreshesTimestamp(t *testing.T) {
 	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
 	client := &cacheRobotClient{
-		now: func() time.Time { return now },
+		now:     func() time.Time { return now },
+		timeout: 5 * time.Minute,
 	}
 
-	client.RememberMissingServerName("bm-missing")
-	firstExpiry := client.missingServerNames["bm-missing"]
+	client.NodeTriggeredForcedRefresh("bm-missing")
+	firstForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
 	now = now.Add(2 * time.Minute)
-	client.RememberMissingServerName("bm-missing")
-	secondExpiry := client.missingServerNames["bm-missing"]
+	client.NodeTriggeredForcedRefresh("bm-missing")
+	secondForcedAt := client.forcedRefreshServerNames["bm-missing"]
 
-	require.True(t, secondExpiry.After(firstExpiry))
+	require.True(t, secondForcedAt.After(firstForcedAt))
 
 	now = now.Add(4 * time.Minute)
-	require.True(t, client.HasMissingServerName("bm-missing"))
+	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
 
-	now = secondExpiry.Add(time.Second)
-	require.False(t, client.HasMissingServerName("bm-missing"))
+	now = secondForcedAt.Add(client.timeout + time.Second)
+	require.False(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+}
+
+func TestServerGetListKeepsForcedRefreshNames(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 10, 0, 0, 0, time.UTC)
+	robotClient := &mocks.RobotClient{}
+	robotClient.On("ServerGetList").Return([]models.Server{
+		{Name: "bm-existing", ServerNumber: 321},
+	}, nil)
+
+	client := &cacheRobotClient{
+		robotClient: robotClient,
+		now:         func() time.Time { return now },
+		timeout:     time.Hour,
+	}
+	client.NodeTriggeredForcedRefresh("bm-missing")
+
+	servers, err := client.ServerGetList()
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.True(t, client.NodeHasAlreadyForcedRefresh("bm-missing"))
+	robotClient.AssertExpectations(t)
 }
 
 func writeCredentials(rootDir, user, password string) error {

--- a/internal/robot/client/interface.go
+++ b/internal/robot/client/interface.go
@@ -5,5 +5,6 @@ import "github.com/syself/hrobot-go/models"
 type Client interface {
 	ServerGet(id int) (*models.Server, error)
 	ServerGetList() ([]models.Server, error)
+	ServerGetListForceRefresh() ([]models.Server, error)
 	SetCredentials(username, password string) error
 }

--- a/internal/robot/client/interface.go
+++ b/internal/robot/client/interface.go
@@ -5,6 +5,5 @@ import "github.com/syself/hrobot-go/models"
 type Client interface {
 	ServerGet(id int) (*models.Server, error)
 	ServerGetList() ([]models.Server, error)
-	ServerGetListForceRefresh() ([]models.Server, error)
 	SetCredentials(username, password string) error
 }

--- a/internal/robot/client/interface.go
+++ b/internal/robot/client/interface.go
@@ -2,8 +2,26 @@ package client
 
 import "github.com/syself/hrobot-go/models"
 
+// Client provides the Robot API operations used by this controller.
 type Client interface {
+	// ServerGet returns the Robot server with the given ID.
 	ServerGet(id int) (*models.Server, error)
+
+	// ServerGetList returns the cached or freshly loaded Robot server list.
 	ServerGetList() ([]models.Server, error)
+
+	// ServerGetListForceRefresh reloads the Robot server list immediately,
+	// bypassing the normal cache timeout.
+	ServerGetListForceRefresh() ([]models.Server, error)
+
+	// NodeHasAlreadyForcedRefresh reports whether nodeName already triggered a
+	// forced Robot list refresh within the current timeout window.
+	NodeHasAlreadyForcedRefresh(nodeName string) bool
+
+	// NodeTriggeredForcedRefresh records that nodeName already triggered a
+	// forced Robot list refresh.
+	NodeTriggeredForcedRefresh(nodeName string)
+
+	// SetCredentials updates the Robot client credentials.
 	SetCredentials(username, password string) error
 }

--- a/internal/robot/client/interface.go
+++ b/internal/robot/client/interface.go
@@ -10,17 +10,10 @@ type Client interface {
 	// ServerGetList returns the cached or freshly loaded Robot server list.
 	ServerGetList() ([]models.Server, error)
 
-	// ServerGetListForceRefresh reloads the Robot server list immediately,
-	// bypassing the normal cache timeout.
-	ServerGetListForceRefresh() ([]models.Server, error)
-
-	// NodeHasAlreadyForcedRefresh reports whether nodeName already triggered a
-	// forced Robot list refresh within the current timeout window.
-	NodeHasAlreadyForcedRefresh(nodeName string) bool
-
-	// NodeTriggeredForcedRefresh records that nodeName already triggered a
-	// forced Robot list refresh.
-	NodeTriggeredForcedRefresh(nodeName string)
+	// ServerGetListForceRefresh reloads the Robot server list immediately for
+	// nodeName, bypassing the normal cache timeout unless that nodeName already
+	// triggered a forced refresh within the current timeout window.
+	ServerGetListForceRefresh(nodeName string) ([]models.Server, error)
 
 	// SetCredentials updates the Robot client credentials.
 	SetCredentials(username, password string) error


### PR DESCRIPTION
Refresh the Robot server cache once when a bare-metal node lookup by name misses in the cached list.

This fixes the case where:
1. the cache is filled,
2. a new bare-metal server is created,
3. `InstanceExists()` looks up the server by name,
4. the cached list is stale and would otherwise return `false`.

## Fix: Deleting node because it does not exist in the cloud provider

Without this fix new Nodes get deleted if the baremetal node is not in the cache yet.

> ... node_controller.go:244] "Unhandled Error" err="error syncing '...': failed to get instance metadata for node bm-...: hcloud/instancesv2.InstanceMetadata: failed to get instance metadata: no matching server found for node 'bm-...': server not found, requeuing" logger="UnhandledError"

> ... event.go:389] "Event occurred" object="bm-..." fieldPath="" kind="Node" apiVersion="v1" type="Normal" reason="DeletingNode" message="Deleting node bm-...because it does not exist in the cloud provider"

## Changes

- add `ServerGetListForceRefresh()` to the Robot client interface
- implement forced cache reload in the cached Robot client
- make `getRobotServerByName()` retry once with a forced refresh after a cache miss
- add a regression test covering:
  - cache filled with `bm-existing`
  - `bm-new` created afterwards
  - `InstanceExists(bm-new)` must return `true`

## Upstream HCloud CCM

Related PR in upstream ccm: [fix robot name lookup after stale cache miss by guettli · Pull Request #1204 · hetznercloud/hcloud-cloud-controller-manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/1204)

